### PR TITLE
[`hf`] Add "library_name" metadata to avoid confusion about what the primary library is

### DIFF
--- a/bm25s/hf.py
+++ b/bm25s/hf.py
@@ -15,6 +15,7 @@ except ImportError:
 
 README_TEMPLATE = """---
 language: en
+library_name: bm25s
 tags:
 - bm25
 - bm25s


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add "library_name" metadata to avoid confusion about what the primary library is

## Details
As you can see in e.g. the `sentence-transformers` metadata, we automatically set the `library_name`: a piece of metadata that prevents Hugging Face from having to guess which of the tags refers to the library. The tags solution isn't a big deal currently, but if there's ever another library called e.g. `lexical`, then things might get tricky.
![image](https://github.com/xhluca/bm25s/assets/37621491/f341d47b-b950-43f9-9870-3f8189119905)

Related: https://github.com/huggingface/huggingface.js/pull/763#discussion_r1645659322

- Tom Aarsen