### PR TITLE
[`compat`] Allow for local install on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import setup, find_packages
 
 package_name = "bm25s"
 version = {}
-with open(f"{package_name}/version.py") as fp:
+with open(f"{package_name}/version.py", encoding="utf8") as fp:
     exec(fp.read(), version)
 
-with open("README.md") as fp:
+with open("README.md", encoding="utf8") as fp:
     long_description = fp.read()
 
 extras_require = {


### PR DESCRIPTION
Hello!

## Pull Request overview
* Allow for local install on Windows

## Details
Currently, the `open("README.md")` in `setup.py` is complaining on Windows with:
```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 344: character maps to <undefined>
```
due to some unexpected character somewhere. Specifying the encoding as UTF-8 is a standard way to allow Windows users to open files safely.

## Unrelated
Another thing, perhaps you can just do:
```python
from bm25s.version import __version__ as version
```
rather than
```python
version = {}
with open(f"{package_name}/version.py", encoding="utf8") as fp:
    exec(fp.read(), version)

...

version["__version__"]
```

Also because I don't like using `exec`, but it's personal preference.

- Tom Aarsen