### PR TITLE
Improve tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,48 @@ retriever = bm25s.BM25.load("bm25s_very_big_index", mmap=True)
 
 For an example of how to use retrieve using the `mmap=True` mode, check out [`examples/retrieve_nq.py`](examples/retrieve_nq.py).
 
+
+## Tokenization
+
+In addition to using the simple function `bm25s.tokenize`, you can also use the `Tokenizer` class to customize the tokenization process. This is useful when you want to use a different tokenizer, or when you want to use a different tokenization process for queries and documents:
+
+```python
+from bm25s.tokenization import Tokenizer
+
+corpus = [
+      "a cat is a feline and likes to purr",
+      "a dog is the human's best friend and loves to play",
+      "a bird is a beautiful animal that can fly",
+      "a fish is a creature that lives in water and swims",
+]
+
+# Pick your favorite stemmer, and pass 
+stemmer = None
+stopwords = []
+splitter = lambda x: x.split() # function or regex pattern
+# Create a tokenizer
+tokenizer = Tokenizer(
+      stemmer=stemmer, stopwords=stopwords, splitter=splitter
+)
+
+corpus_tokens = tokenizer.tokenize(corpus)
+
+# let's see what the tokens look like
+print("tokens:", corpus_tokens)
+print("vocab:", tokenizer.get_vocab_dict())
+
+# note: the vocab dict will either be a dict of `word -> id` if you don't have a stemmer, and a dict of `stemmed word -> stem id` if you do.
+```
+
+You can find advanced examples in [examples/tokenizer_class.py](examples/tokenizer_class.py), including how to:
+* Pass a stemmer, stopwords, and splitter function/regex pattern
+* Control whether vocabulary is updated by `tokenizer.tokenize` calls or not (by default, it will only be updated during the first call)
+* Reset the tokenizer to its initial state with `tokenizer.reset_vocab()`
+* Use the tokenizer in generator mode to save memory by `yield`ing one document at a time.
+* Pass different outputs of the tokenizer to the `BM25.retrieve` function.
+
+
+
 ## Variants
 
 You can use the following variants of BM25 in `bm25s` (see [Kamphuis et al. 2020](https://link.springer.com/chapter/10.1007/978-3-030-45442-5_4) for more details):

--- a/bm25s/tokenization.py
+++ b/bm25s/tokenization.py
@@ -65,7 +65,9 @@ class Tokenizer:
     def reset_vocab(self):
         self.word_to_stem = {}  # word -> stemmed word, e.g. "apple" -> "appl"
         self.stem_to_sid = {}  # stem -> stemmed id, e.g. "appl" -> 0
-        self.word_to_id = {}  # word -> {stemmed, unstemmed} id, e.g. "apple" -> 0 (appl) or "apple" -> 2 (apple)
+        self.word_to_id = (
+            {}
+        )  # word -> {stemmed, unstemmed} id, e.g. "apple" -> 0 (appl) or "apple" -> 2 (apple)
 
     def streaming_tokenize(self, texts: List[str], update_vocab: bool = True):
         """
@@ -75,20 +77,20 @@ class Tokenizer:
         ----------
         texts : List[str]
             A list of strings to tokenize.
-        
+
         update_vocab : bool, optional
             Whether to update the vocabulary dictionary with the new tokens. If true,
             the different dictionaries making up the vocabulary will be updated with the
-            new tokens. If False, the function will not update the vocabulary. Unless you have 
+            new tokens. If False, the function will not update the vocabulary. Unless you have
             a stemmer and the stemmed word is in the stem_to_sid dictionary.  If "never",
             the function will never update the vocabulary, even if the stemmed word is in
-            the stem_to_sid dictionary. Note that update_vocab="if_empty" is not supported 
+            the stem_to_sid dictionary. Note that update_vocab="if_empty" is not supported
             in this method, only in the `tokenize` method.
         """
         stopwords_set = set(self.stopwords) if self.stopwords is not None else None
         using_stopwords = stopwords_set is not None
         using_stemmer = self.stemmer is not None
-        
+
         for text in texts:
             if self.lower:
                 text = text.lower()
@@ -122,7 +124,7 @@ class Tokenizer:
                         sid = self.stem_to_sid[stem]
                         self.word_to_id[word] = sid
                         doc_ids.append(sid)
-                        
+
                     elif update_vocab is True:
                         sid = len(self.stem_to_sid)
                         self.stem_to_sid[stem] = sid
@@ -135,7 +137,6 @@ class Tokenizer:
                         wid = len(self.word_to_id)
                         self.word_to_id[word] = wid
                         doc_ids.append(wid)
-
 
             yield doc_ids
 
@@ -155,35 +156,35 @@ class Tokenizer:
         ----------
         texts : List[str]
             A list of strings to tokenize.
-        
+
         update_vocab : bool, optional
             Whether to update the vocabulary dictionary with the new tokens. If true,
             the different dictionaries making up the vocabulary will be updated with the
             new tokens. If False, the vocabulary will not be updated unless you have a stemmer
-            and the stemmed word is in the stem_to_sid dictionary. If update_vocab="if_empty", 
-            the function will only update the vocabulary if it is empty, i.e. when the 
-            function is called for the first time, or if the vocabulary has been reset with 
-            the `reset_vocab` method. If update_vocab="never", the "word_to_id" will never 
-            be updated, even if the stemmed word is in the stem_to_sid dictionary. Only use 
+            and the stemmed word is in the stem_to_sid dictionary. If update_vocab="if_empty",
+            the function will only update the vocabulary if it is empty, i.e. when the
+            function is called for the first time, or if the vocabulary has been reset with
+            the `reset_vocab` method. If update_vocab="never", the "word_to_id" will never
+            be updated, even if the stemmed word is in the stem_to_sid dictionary. Only use
             this if you are sure that the stemmed words are already in the stem_to_sid dictionary.
-        
+
         leave_progress : bool, optional
             Whether to leave the progress bar after completion. If False, the progress bar
             will disappear after completion. If True, the progress bar will stay on the screen.
-        
+
         show_progress : bool, optional
             Whether to show the progress bar for tokenization. If False, the function will
             not show the progress bar. If True, it will use tqdm.auto to show the progress bar.
-        
+
         length : int, optional
             The length of the texts. If None, the function will use the length of the texts.
             This is mainly used when `texts` is a generator or a stream instead of a list.
-        
+
         return_as : str, optional
             The type of object to return by this function.
-            If "tuple", this returns a Tokenized namedtuple, which contains the token IDs 
-            and the vocab dictionary. 
-            If "string", this return a list of lists of strings, each string being a token. 
+            If "tuple", this returns a Tokenized namedtuple, which contains the token IDs
+            and the vocab dictionary.
+            If "string", this return a list of lists of strings, each string being a token.
             If "ids", this return a list of lists of integers corresponding to the token IDs,
             or stemmed IDs if a stemmer is used.
 
@@ -195,17 +196,21 @@ class Tokenizer:
             If `return_as="string"`, a List[List[str]] is returned, each string being a token.
             If `return_as="tuple"`, a Tokenized namedtuple is returned, with names `ids` and `vocab`.
         """
-        incorrect_return_error = "return_as must be either 'tuple', 'string', 'ids', or 'stream'."
-        incorrect_update_vocab_error = "update_vocab must be either True, False, 'if_empty', or 'never'."
+        incorrect_return_error = (
+            "return_as must be either 'tuple', 'string', 'ids', or 'stream'."
+        )
+        incorrect_update_vocab_error = (
+            "update_vocab must be either True, False, 'if_empty', or 'never'."
+        )
         if return_as not in ["tuple", "string", "ids", "stream"]:
             raise ValueError(incorrect_return_error)
-        
+
         if update_vocab not in [True, False, "if_empty", "never"]:
             raise ValueError(incorrect_update_vocab_error)
 
         if update_vocab == "if_empty":
             update_vocab = len(self.word_to_id) == 0
-        
+
         stream_fn = self.streaming_tokenize(texts=texts, update_vocab=update_vocab)
 
         if return_as == "stream":
@@ -213,7 +218,7 @@ class Tokenizer:
 
         if length is None:
             length = len(texts)
-        
+
         tqdm_kwargs = dict(
             desc="Tokenize texts",
             leave=leave_progress,
@@ -234,7 +239,6 @@ class Tokenizer:
         else:
             raise ValueError(incorrect_return_error)
 
-    
     def get_vocab_dict(self) -> Dict[str, Any]:
         if self.stemmer is None:
             # if we are not using a stemmer, we return the word_to_id dictionary
@@ -249,22 +253,21 @@ class Tokenizer:
         """
         Convert the token IDs to a Tokenized namedtuple, which contains the word IDs, or the stemmed IDs
         if a stemmer is used. The Tokenized namedtuple contains two fields: ids and vocab. The latter
-        is a dictionary mapping the token IDs to the tokens, or a dictionary mapping the stemmed IDs to 
+        is a dictionary mapping the token IDs to the tokens, or a dictionary mapping the stemmed IDs to
         the stemmed tokens (if a stemmer is used).
         """
         return Tokenized(ids=docs, vocab=self.get_vocab_dict())
-    
+
     def to_lists_of_strings(self, docs: List[List[int]]) -> List[List[str]]:
         """
         Convert word IDs (or stemmed IDs if a stemmer is used) back to strings using the vocab dictionary,
-        which is a dictionary mapping the word IDs to the words or a dictionary mapping the stemmed IDs 
+        which is a dictionary mapping the word IDs to the words or a dictionary mapping the stemmed IDs
         to the stemmed words (if a stemmer is used).
         """
         vocab = self.get_vocab_dict()
         reverse_vocab = {v: k for k, v in vocab.items()}
-        return [
-            [reverse_vocab[token_id] for token_id in doc] for doc in docs
-        ]
+        return [[reverse_vocab[token_id] for token_id in doc] for doc in docs]
+
 
 def convert_tokenized_to_string_list(tokenized: Tokenized) -> List[List[str]]:
     """
@@ -463,48 +466,3 @@ def tokenize(
             corpus_ids[i] = [reverse_dict[token_id] for token_id in token_ids]
 
         return corpus_ids
-
-
-def _tokenize_with_vocab_exp(
-    texts: Union[str, List[str]],
-    lower: bool = True,
-    token_pattern: str = r"(?u)\b\w\w+\b",
-    stopwords: Union[str, List[str]] = "english",
-    vocab_dict: dict = None,
-    show_progress: bool = True,
-    leave: bool = False,
-) -> Tokenized:
-    if isinstance(texts, str):
-        texts = [texts]
-
-    if vocab_dict is None:
-        raise ValueError("vocab_dict must be provided.")
-
-    token_pattern = re.compile(token_pattern)
-    stopwords = _infer_stopwords(stopwords)
-
-    corpus_ids = []
-    stopwords_set = set(stopwords)
-    for text in tqdm(
-        texts, desc="Split strings", leave=leave, disable=not show_progress
-    ):
-        if lower:
-            text = text.lower()
-
-        splitted = token_pattern.findall(text)
-
-        doc_ids = []
-
-        for token in splitted:
-            if token in stopwords_set:
-                continue
-
-            if token not in vocab_dict:
-                continue
-
-            doc_ids.append(vocab_dict[token])
-
-        corpus_ids.append(doc_ids)
-
-    # Step 3: Return the tokenized IDs and the vocab dictionary or the tokenized strings
-    return corpus_ids

--- a/bm25s/utils/beir.py
+++ b/bm25s/utils/beir.py
@@ -10,7 +10,7 @@ except ImportError:
 from . import json_functions
 
 BASE_URL = "https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/{}.zip"
-
+GH_URL = "https://github.com/xhluca/bm25s/releases/download/data/{}.zip"
 
 def clean_results_keys(beir_results):
     return {k.split("@")[-1]: v for k, v in beir_results.items()}

--- a/examples/tokenizer_class.py
+++ b/examples/tokenizer_class.py
@@ -52,14 +52,23 @@ def main(data_dir="datasets", dataset="scifact"):
         if 1 in q:
             query_ids.append(q)
 
-    # you can convert the ids to a Tokenized namedtuple ids and tokens
+    # you can convert the ids to a Tokenized namedtuple ids and tokens...
     res = tokenizer.to_tokenized_tuple(query_ids)
+    # ... which is equivalent to: 
+    # tokenizer.tokenize(your_query_lst, return_as="tuple", update_vocab=False)
+
+    # You can verify the results
     assert res.ids == query_ids
     assert res.vocab == tokenizer.get_vocab_dict()
     assert isinstance(res, Tokenized)
+
     
     # You can also get strings
     query_strs = tokenizer.to_lists_of_strings(query_ids)
+    # ... which is equivalent to: 
+    # tokenizer.tokenize(your_query_lst, return_as="string", update_vocab=False)
+
+    # let's verify the results
     assert isinstance(query_strs, list)
     assert isinstance(query_strs[0], list)
     assert isinstance(query_strs[0][0], str)

--- a/examples/tokenizer_class.py
+++ b/examples/tokenizer_class.py
@@ -83,6 +83,9 @@ def main(data_dir="datasets", dataset="scifact"):
     vocab_dict = tokenizer.get_vocab_dict()
     results, scores = retriever.retrieve((query_ids, vocab_dict), k=3)
 
+    # Unhappy with your vocab? you can reset your tokenizer
+    tokenizer.reset_vocab()
+
 
 if __name__ == "__main__":
     main()

--- a/examples/tokenizer_class_example.py
+++ b/examples/tokenizer_class_example.py
@@ -1,0 +1,34 @@
+import bm25s
+import Stemmer
+
+stemmer = Stemmer.Stemmer('english')
+
+tokenizer = bm25s.tokenization.Tokenizer(stemmer=stemmer)
+
+# Tokenize a string
+texts = [
+    "This is a test string",
+    "Here is another test string!"
+]
+
+stream = tokenizer.streaming_tokenize(texts)
+
+print("1", tokenizer.vocab)
+
+print(next(stream))
+
+print("2", tokenizer.vocab)
+
+print(next(stream))
+
+print("3", tokenizer.vocab)
+
+print('-'*20)
+tokenizer.reset_vocab()
+
+for token in tokenizer.streaming_tokenize(texts):
+    print(token)
+
+print(tokenizer.tokenize(texts, show_progress=True, leave_progress=True))
+
+# todo: test with and without stemming, without and without stopwords, with and without lowercasing

--- a/examples/tokenizer_class_example.py
+++ b/examples/tokenizer_class_example.py
@@ -32,3 +32,4 @@ for token in tokenizer.streaming_tokenize(texts):
 print(tokenizer.tokenize(texts, show_progress=True, leave_progress=True))
 
 # todo: test with and without stemming, without and without stopwords, with and without lowercasing
+# todo: test inputs to retriever.retrieve() with both list of strings and list of lists of strings and ids and list of of list of ids

--- a/examples/tokenizer_class_example.py
+++ b/examples/tokenizer_class_example.py
@@ -1,35 +1,89 @@
-import bm25s
+"""
+# Example: Retrieve from pre-built index of SciFact
+
+This script shows how to load an index built with BM25.index and saved with BM25.save, and retrieve
+the top-k results for a set of queries from the SciFact dataset, via the BEIR library.
+"""
+import beir.util
+from beir.datasets.data_loader import GenericDataLoader
 import Stemmer
 
-stemmer = Stemmer.Stemmer('english')
+import bm25s
+from bm25s.utils.beir import BASE_URL
+from bm25s.tokenization import Tokenizer, Tokenized
 
-tokenizer = bm25s.tokenization.Tokenizer(stemmer=stemmer)
 
-# Tokenize a string
-texts = [
-    "This is a test string",
-    "Here is another test string!"
-]
+def main(data_dir="datasets", dataset="scifact"):
+    # Load the queries from BEIR
+    data_path = beir.util.download_and_unzip(BASE_URL.format(dataset), data_dir)
+    loader = GenericDataLoader(data_folder=data_path)
+    corpus, queries, qrels = GenericDataLoader(data_folder=data_path).load(split='test')
+    corpus_lst = [doc["title"] + " " + doc["text"] for doc in corpus.values()]
+    queries_lst = list(queries.values())
 
-stream = tokenizer.streaming_tokenize(texts)
+    # Initialize the stemmer
+    stemmer = Stemmer.Stemmer("english")
 
-print("1", tokenizer.vocab)
+    # Initialize the Tokenizer with the stemmer
+    tokenizer = Tokenizer(
+        stemmer=stemmer,
+        lower=True, # lowercase the tokens
+        stopwords="english",  # or pass a list of stopwords
+        splitter=r"\w+",  # by default r"(?u)\b\w\w+\b", can also be a function
+    )
 
-print(next(stream))
+    # Tokenize the corpus
+    corpus_tokenized = tokenizer.tokenize(
+        corpus_lst, 
+        update_vocab=True, # update the vocab as we tokenize
+        return_as="ids"
+    )
 
-print("2", tokenizer.vocab)
+    # stream tokenizing the queries, without updating the vocabulary
+    # note: this cannot return as string due to the streaming nature
+    tokenizer_stream = tokenizer.streaming_tokenize(
+        queries_lst, 
+        update_vocab=False
+    )
+    query_ids = []
 
-print(next(stream))
+    for q in tokenizer_stream:
+        # you can do something with the ids here, e.g. retrieve from the index
+        if 1 in q:
+            query_ids.append(q)
 
-print("3", tokenizer.vocab)
+    # you can convert the ids to a Tokenized namedtuple ids and tokens
+    res = tokenizer.to_tokenized_tuple(query_ids)
+    assert res.ids == query_ids
+    assert res.vocab == tokenizer.get_vocab_dict()
+    assert isinstance(res, Tokenized)
+    
+    # You can also get strings
+    query_strs = tokenizer.to_lists_of_strings(query_ids)
+    assert isinstance(query_strs, list)
+    assert isinstance(query_strs[0], list)
+    assert isinstance(query_strs[0][0], str)
 
-print('-'*20)
-tokenizer.reset_vocab()
+    # Let's see how it's all used
+    retriever = bm25s.BM25()
+    retriever.index(corpus_tokenized, leave_progress=False)
 
-for token in tokenizer.streaming_tokenize(texts):
-    print(token)
+    # all of the above can be passed to index a bm25s model
 
-print(tokenizer.tokenize(texts, show_progress=True, leave_progress=True))
+    # e.g. using the ids directly
+    results, scores = retriever.retrieve(query_ids, k=3)
 
-# todo: test with and without stemming, without and without stopwords, with and without lowercasing
-# todo: test inputs to retriever.retrieve() with both list of strings and list of lists of strings and ids and list of of list of ids
+    # or passing the strings
+    results, scores = retriever.retrieve(query_strs, k=3)
+
+    # or passing the Tokenized namedtuple
+    results, scores = retriever.retrieve(res, k=3)
+    
+    # or passing a tuple of ids and vocab dict
+    vocab_dict = tokenizer.get_vocab_dict()
+    results, scores = retriever.retrieve((query_ids, vocab_dict), k=3)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/core/test_tokenizer.py
+++ b/tests/core/test_tokenizer.py
@@ -1,0 +1,135 @@
+import unittest
+import Stemmer
+import re
+
+from bm25s.tokenization import Tokenizer
+
+class TestTokenizer(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Define a sample corpus
+        cls.corpus = [
+            "This is a test sentence.",
+            "Another sentence for testing.",
+            "Machine learning is fun!",
+            "The quick brown fox jumps over the lazy dog.",
+        ]
+
+        # Initialize a stemmer
+        cls.stemmer = Stemmer.Stemmer("english")
+
+    def setUp(self):
+        # Initialize the Tokenizer with default settings
+        self.tokenizer = Tokenizer(stemmer=self.stemmer)
+
+    def test_tokenize_with_default_settings(self):
+        """Tests the `tokenize` method with default settings."""
+        result = self.tokenizer.tokenize(self.corpus, update_vocab=True, return_as="ids")
+        self.assertIsInstance(result, list)
+        for doc in result:
+            self.assertIsInstance(doc, list)
+            for token_id in doc:
+                self.assertIsInstance(token_id, int)
+
+    def test_tokenize_with_custom_splitter(self):
+        """Tests the `tokenize` method and `__init__` method with a custom splitter."""
+        custom_splitter = lambda text: re.findall(r"\w+", text)
+        tokenizer = Tokenizer(splitter=custom_splitter, stemmer=self.stemmer)
+        result = tokenizer.tokenize(self.corpus, update_vocab=True, return_as="ids")
+        self.assertIsInstance(result, list)
+
+    def test_tokenize_with_stopwords(self):
+        """Tests the `tokenize` method and `__init__` method with stopwords filtering."""
+        stopwords = ["is", "a", "for"]
+        tokenizer = Tokenizer(stopwords=stopwords, stemmer=self.stemmer)
+        result = tokenizer.tokenize(self.corpus, update_vocab=True, return_as="string")
+        for doc in result:
+            for token in doc:
+                self.assertNotIn(token, stopwords)
+
+    def test_tokenize_with_never_update_vocab(self):
+        """Tests the `tokenize` method with the `update_vocab="never"` parameter."""
+        tokenizer = Tokenizer(stemmer=self.stemmer)
+        tokenizer.tokenize(self.corpus, update_vocab="never")
+        vocab_size = len(tokenizer.get_vocab_dict())
+        self.assertEqual(vocab_size, 0)
+
+    def test_invalid_splitter(self):
+        """Tests the `__init__` method for handling an invalid `splitter` input."""
+        with self.assertRaises(ValueError):
+            Tokenizer(splitter=123)
+
+    def test_invalid_stemmer(self):
+        """Tests the `__init__` method for handling an invalid `stemmer` input."""
+        with self.assertRaises(ValueError):
+            Tokenizer(stemmer="not_callable")
+
+    def test_tokenize_with_empty_vocab(self):
+        """Tests the `tokenize` method with the `update_vocab="if_empty"` parameter."""
+        tokenizer = Tokenizer(stemmer=self.stemmer)
+        tokenizer.tokenize(self.corpus, update_vocab="if_empty")
+        vocab_size = len(tokenizer.get_vocab_dict())
+        self.assertGreater(vocab_size, 0)
+
+    def test_streaming_tokenize(self):
+        """Tests the `streaming_tokenize` method directly for its functionality."""
+        stream = self.tokenizer.streaming_tokenize(self.corpus)
+        for doc_ids in stream:
+            self.assertIsInstance(doc_ids, list)
+            for token_id in doc_ids:
+                self.assertIsInstance(token_id, int)
+
+    def test_get_vocab_dict(self):
+        """Tests the `get_vocab_dict` method to ensure it returns the correct vocabulary dictionary."""
+        self.tokenizer.tokenize(self.corpus, update_vocab=True)
+        vocab = self.tokenizer.get_vocab_dict()
+        self.assertIsInstance(vocab, dict)
+        self.assertGreater(len(vocab), 0)
+
+    def test_tokenize_return_types(self):
+        """Tests the `tokenize` method with different `return_as` parameter values (`ids`, `string`, `tuple`)."""
+        result_ids = self.tokenizer.tokenize(self.corpus, return_as="ids")
+        result_strings = self.tokenizer.tokenize(self.corpus, return_as="string")
+        result_tuple = self.tokenizer.tokenize(self.corpus, return_as="tuple")
+
+        self.assertIsInstance(result_ids, list)
+        self.assertIsInstance(result_strings, list)
+        self.assertIsInstance(result_tuple, tuple)
+
+    def test_tokenize_with_invalid_return_type(self):
+        """Tests the `tokenize` method for handling an invalid `return_as` parameter value."""
+        with self.assertRaises(ValueError):
+            self.tokenizer.tokenize(self.corpus, return_as="invalid_type")
+
+    def test_reset_vocab(self):
+        """Tests the `reset_vocab` method to ensure it properly clears all vocabulary dictionaries."""
+        self.tokenizer.tokenize(self.corpus, update_vocab=True)
+        self.tokenizer.reset_vocab()
+        vocab = self.tokenizer.get_vocab_dict()
+        self.assertEqual(len(vocab), 0)
+
+    def test_to_tokenized_tuple(self):
+        """Tests the `to_tokenized_tuple` method to ensure it correctly converts token IDs to a named tuple."""
+        docs = self.tokenizer.tokenize(self.corpus, return_as="ids")
+        tokenized_tuple = self.tokenizer.to_tokenized_tuple(docs)
+        self.assertIsInstance(tokenized_tuple, tuple)
+        self.assertEqual(len(tokenized_tuple.ids), len(docs))
+
+    def test_to_lists_of_strings(self):
+        """Tests the `to_lists_of_strings` method to ensure it converts token IDs back to strings properly."""
+        docs = self.tokenizer.tokenize(self.corpus, return_as="ids")
+        strings = self.tokenizer.to_lists_of_strings(docs)
+        self.assertIsInstance(strings, list)
+        for doc in strings:
+            self.assertIsInstance(doc, list)
+            for token in doc:
+                self.assertIsInstance(token, str)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Cleans up resources after all tests have run (not required in this test case)."""
+        pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Closes #31
* Makes tokenizing queries much faster since we don't need to rebuild the vocab (can just use the existing vocab from the corpus

# TODO

- [x] add better examples
    - [x] Streaming via generator, and calling next
    - [x] tokenize in int, ids, strings, tuple
    - [x] show tokenizing corpus -> tokenize queries
- [ ] add tests for `BM25.retrieve` under each possible condition:
    - [ ] `Tokenized` namedtuple
    - [ ] Object with `ids` and `vocab`
    - [ ] tuple (not `Tokenized` namedtuple) of ids and vocab
    - [ ] ids: `List[List[int]]`
    - [ ] strings: `List[List[str]]`
- [x] add tests for `Tokenizer.tokenize`, where it generates:
    - [x] `Tokenized` namedtuple
    - [x] Object with `ids` and `vocab`
    - [x] tuple (not `Tokenized` namedtuple) of ids and vocab
    - [x] ids: `List[List[int]]`
    - [x] strings: `List[List[str]]`
- [x] add tests for `Tokenizer.streaming_tokenize`