### PR TITLE
Add features to improve memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ For `pyserini`, we use the [recommended installation](https://github.com/castori
 
 Using the `index_nq.py` to create an index, we can retrieve with:
 * `examples/retrieve_nq.py`: setting `mmap=False` in the `main` function to load the index in memory, and `mmap=True` to load the index as a memory-mapped file. 
-* `examples/retrieve_nq_with_batching.py`: This takes it a step further by batching the retrieval process, which allows for reloading the index after each batch. This is useful when you have a large index and want to save memory.
+* `examples/retrieve_nq_with_batching.py`: This takes it a step further by batching the retrieval process, which allows for reloading the index after each batch (see *Mmap+Reload* below). This is useful when you have a large index and want to save memory.
 
 we show the following results on the NQ dataset (2M+ documents, 100M+ tokens):
 
@@ -416,9 +416,16 @@ we show the following results on the NQ dataset (2M+ documents, 100M+ tokens):
 | ------------- | -------------- | ------------- | ------------------- | ---------------------- |
 | In-memory     | 8.61           | 21.09         | 4.36                | 4.45                   |
 | Memory-mapped | 0.53           | 20.22         | 0.49                | 2.16                   |
-| Mmap+Reload after batch | 0.48           | 20.96         | 0.49                | 0.70                   |
+| Mmap+Reload   | 0.48           | 20.96         | 0.49                | 0.70                   |
 
-We can see that memory-mapping the index allows for a significant reduction in memory usage, with comparable retrieval times.
+We can see that memory-mapping the index allows for a significant reduction in memory usage, with comparable retrieval times. 
+
+Similarly, for MSMARCO (8M+ documents, 300M+ tokens), we show the following results (running on the validation set), although the retrieval did not complete for the in-memory case:
+
+| Method        | Load Index (s) | Retrieval (s) | RAM post-index (GB) | RAM post-retrieve (GB) |
+| ------------- | -------------- | ------------- | ------------------- | ---------------------- |
+| In-memory     | 26.06          | ?          | 10.27               | ?                   |
+| Mmap+Reload   | 1.20           | 101.17        | 1.15                | 1.38                   |
 
 ## Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -420,12 +420,12 @@ we show the following results on the NQ dataset (2M+ documents, 100M+ tokens):
 
 We can see that memory-mapping the index allows for a significant reduction in memory usage, with comparable retrieval times. 
 
-Similarly, for MSMARCO (8M+ documents, 300M+ tokens), we show the following results (running on the validation set), although the retrieval did not complete for the in-memory case:
+Similarly, for MSMARCO (8M+ documents, 300M+ tokens), we show the following results (running on the validation set), although the retrieval did not complete for the in-memory case (* denotes that the retrieval did not terminate):
 
-| Method        | Load Index (s) | Retrieval (s) | RAM post-index (GB) | RAM post-retrieve (GB) |
-| ------------- | -------------- | ------------- | ------------------- | ---------------------- |
-| In-memory     | 26.06          | ?          | 10.27               | ?                   |
-| Mmap+Reload   | 1.20           | 101.17        | 1.15                | 1.38                   |
+| Method      | Load Index (s) | Retrieval (s) | RAM post-index (GB) | RAM post-retrieve (GB) |
+| ----------- | -------------- | ------------- | ------------------- | ---------------------- |
+| In-memory   | 26.06          | DNT             | 10.27               | 18.59*                 |
+| Mmap+Reload | 1.20           | 101.17        | 1.15                | 1.38                   |
 
 ## Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -422,10 +422,11 @@ We can see that memory-mapping the index allows for a significant reduction in m
 
 Similarly, for MSMARCO (8M+ documents, 300M+ tokens), we show the following results (running on the validation set), although the retrieval did not complete for the in-memory case (* denotes that the retrieval did not terminate):
 
-| Method      | Load Index (s) | Retrieval (s) | RAM post-index (GB) | RAM post-retrieve (GB) |
-| ----------- | -------------- | ------------- | ------------------- | ---------------------- |
-| In-memory   | 26.06          | DNT             | 10.27               | 18.59*                 |
-| Mmap+Reload | 1.20           | 101.17        | 1.15                | 1.38                   |
+| Method        | Load Index (s) | Retrieval (s) | RAM post-index (GB) | RAM post-retrieve (GB) |
+| ------------- | -------------- | ------------- | ------------------- | ---------------------- |
+| In-memory     | 25.71          | 93.66         | 10.21               | 10.34                  |
+| Memory-mapped | 1.24           | 90.41         | 1.14                | 4.88                   |
+| Mmap+Reload   | 1.17           | 97.89         | 1.14                | 1.38                   |
 
 ## Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -351,23 +351,23 @@ Here are some benchmarks comparing `bm25s` to other popular BM25 implementations
 
 We compare the throughput of the BM25 implementations on various datasets. The throughput is measured in queries per second (QPS), on a single-threaded Intel Xeon CPU @ 2.70GHz (found on Kaggle). For BM25S, we take the average of 10 runs. Instances exceeding 60 queries/s are in **bold**.
 
-| Dataset          |   BM25S | Elastic | BM25-PT | Rank-BM25 |
-| :--------------- | ------: | ------: | ------: | --------: |
-| arguana          |  **573.91** |   13.67 |  **110.51** |         2 |
-| climate-fever    |   13.09 |    4.02 |     OOM |      0.03 |
-| cqadupstack      |  **170.91** |   13.38 |     OOM |      0.77 |
-| dbpedia-entity   |   13.44 |   10.68 |     OOM |      0.11 |
-| fever            |   20.19 |    7.45 |     OOM |      0.06 |
-| fiqa             |  **507.03** |   16.96 |   20.52 |      4.46 |
-| hotpotqa         |   20.88 |    7.11 |     OOM |      0.04 |
-| msmarco          |    12.2 |   11.88 |     OOM |      0.07 |
-| nfcorpus         | **1196.16** |   45.84 |  256.67 |    **224.66** |
-| nq               |   41.85 |   12.16 |     OOM |       0.1 |
-| quora            |  **183.53** |    21.8 |    6.49 |      1.18 |
-| scidocs          |  **767.05** |   17.93 |   41.34 |      9.01 |
-| scifact          |  **952.92** |   20.81 |   **184.3** |      47.6 |
-| trec-covid       |   **85.64** |    7.34 |    3.73 |      1.48 |
-| webis-touche2020 |   **60.59** |   13.53 |     OOM |       1.1 |
+| Dataset          |       BM25S | Elastic |    BM25-PT |  Rank-BM25 |
+| :--------------- | ----------: | ------: | ---------: | ---------: |
+| arguana          |  **573.91** |   13.67 | **110.51** |          2 |
+| climate-fever    |       13.09 |    4.02 |        OOM |       0.03 |
+| cqadupstack      |  **170.91** |   13.38 |        OOM |       0.77 |
+| dbpedia-entity   |       13.44 |   10.68 |        OOM |       0.11 |
+| fever            |       20.19 |    7.45 |        OOM |       0.06 |
+| fiqa             |  **507.03** |   16.96 |      20.52 |       4.46 |
+| hotpotqa         |       20.88 |    7.11 |        OOM |       0.04 |
+| msmarco          |        12.2 |   11.88 |        OOM |       0.07 |
+| nfcorpus         | **1196.16** |   45.84 |     256.67 | **224.66** |
+| nq               |       41.85 |   12.16 |        OOM |        0.1 |
+| quora            |  **183.53** |    21.8 |       6.49 |       1.18 |
+| scidocs          |  **767.05** |   17.93 |      41.34 |       9.01 |
+| scifact          |  **952.92** |   20.81 |  **184.3** |       47.6 |
+| trec-covid       |   **85.64** |    7.34 |       3.73 |       1.48 |
+| webis-touche2020 |   **60.59** |   13.53 |        OOM |        1.1 |
 
 More detailed benchmarks can be found in the [bm25-benchmarks repo](https://github.com/xhluca/bm25-benchmarks).
 
@@ -406,14 +406,19 @@ For `pyserini`, we use the [recommended installation](https://github.com/castori
 
 `bm25s` allows considerable memory saving through the use of *memory-mapping*, which allows the index to be stored on disk and loaded on demand. 
 
-When testing with 6 arbitrary queries with an index built with MS MARCO (8.8M documents, 300M+ tokens), we have the following:
+Using the `index_nq.py` to create an index, we can retrieve with:
+* `examples/retrieve_nq.py`: setting `mmap=False` in the `main` function to load the index in memory, and `mmap=True` to load the index as a memory-mapped file. 
+* `examples/retrieve_nq_with_batching.py`: This takes it a step further by batching the retrieval process, which allows for reloading the index after each batch. This is useful when you have a large index and want to save memory.
 
-| Method | Load Index (s) | Retrieval (s) | RAM usage (GB) |
-| ------ | ----------------- | ------------- | -------------- |
-| Memory-mapped | 0.62 | 0.18 | 0.90 |
-| In-memory | 11.41 | 0.74 | 10.56 |
+we show the following results on the NQ dataset (2M+ documents, 100M+ tokens):
 
-When you run `bm25s` on 1000 queries on the Natural Questions dataset (2M+ documents), the memory usage is over 50% lower than the in-memory version with trivial difference in speed. You can find more information in the [GitHub repository](https://github.com/xhluca/bm25s).
+| Method        | Load Index (s) | Retrieval (s) | RAM post-index (GB) | RAM post-retrieve (GB) |
+| ------------- | -------------- | ------------- | ------------------- | ---------------------- |
+| In-memory     | 8.61           | 21.09         | 4.36                | 4.45                   |
+| Memory-mapped | 0.53           | 20.22         | 0.49                | 2.16                   |
+| Mmap+Reload after batch | 0.48           | 20.96         | 0.49                | 0.70                   |
+
+We can see that memory-mapping the index allows for a significant reduction in memory usage, with comparable retrieval times.
 
 ## Acknowledgement
 

--- a/bm25s/__init__.py
+++ b/bm25s/__init__.py
@@ -62,6 +62,18 @@ class Results(NamedTuple):
     documents: np.ndarray
     scores: np.ndarray
 
+    def __len__(self):
+        return len(self.documents)
+
+    @classmethod
+    def merge(cls, results: List["Results"]) -> "Results":
+        """
+        Merge a list of Results objects into a single Results object.
+        """
+        documents = np.concatenate([r.documents for r in results], axis=0)
+        scores = np.concatenate([r.scores for r in results], axis=0)
+        return cls(documents=documents, scores=scores)
+
 
 def get_unique_tokens(
     corpus_tokens, show_progress=True, leave_progress=False, desc="Create Vocab"

--- a/bm25s/__init__.py
+++ b/bm25s/__init__.py
@@ -867,6 +867,62 @@ class BM25:
             mmidx = utils.corpus.find_newline_positions(save_dir / corpus_name)
             utils.corpus.save_mmindex(mmidx, path=save_dir / corpus_name)
 
+    def load_scores(
+        self, 
+        save_dir,
+        data_name="data.csc.index.npy",
+        indices_name="indices.csc.index.npy",
+        indptr_name="indptr.csc.index.npy",
+        num_docs=None,
+        mmap=False,
+        allow_pickle=False,
+    ):
+        """
+        Load the scores arrays from the BM25 index. This is useful if you want to load
+        the scores arrays separately from the vocab dictionary and the parameters.
+
+        This is called internally by the `load` method, so you do not need to call it directly.
+
+        Parameters
+        ----------
+        data_name : str
+            The name of the file that contains the data array.
+
+        indices_name : str
+            The name of the file that contains the indices array.
+
+        indptr_name : str
+            The name of the file that contains the indptr array.
+
+        mmap : bool
+            Whether to use Memory-map for the np.load function. If false, the arrays will be loaded into memory.
+            If True, the arrays will be memory-mapped, using 'r' mode. This is useful for very large arrays that
+            do not fit into memory.
+
+        allow_pickle : bool
+            If True, the arrays will be loaded using pickle. If False, the arrays will be loaded
+            in a more efficient format, but they will not be readable by older versions of numpy.
+        """
+        save_dir = Path(save_dir)
+
+        data_path = save_dir / data_name
+        indices_path = save_dir / indices_name
+        indptr_path = save_dir / indptr_name
+
+        mmap_mode = "r" if mmap else None
+        data = np.load(data_path, allow_pickle=allow_pickle, mmap_mode=mmap_mode)
+        indices = np.load(indices_path, allow_pickle=allow_pickle, mmap_mode=mmap_mode)
+        indptr = np.load(indptr_path, allow_pickle=allow_pickle, mmap_mode=mmap_mode)
+
+        scores = {}
+        scores["data"] = data
+        scores["indices"] = indices
+        scores["indptr"] = indptr
+        scores["num_docs"] = num_docs
+
+        self.scores = scores
+
+
     @classmethod
     def load(
         cls,
@@ -941,29 +997,22 @@ class BM25:
         with open(vocab_path, "r") as f:
             vocab_dict: dict = json_functions.loads(f.read())
 
-        # Load the score arrays
-        data_path = save_dir / data_name
-        indices_path = save_dir / indices_name
-        indptr_path = save_dir / indptr_name
-
-        mmap_mode = "r" if mmap else None
-        data = np.load(data_path, allow_pickle=allow_pickle, mmap_mode=mmap_mode)
-        indices = np.load(indices_path, allow_pickle=allow_pickle, mmap_mode=mmap_mode)
-        indptr = np.load(indptr_path, allow_pickle=allow_pickle, mmap_mode=mmap_mode)
-
         original_version = params.pop("version", None)
-
-        scores = {
-            "data": data,
-            "indices": indices,
-            "indptr": indptr,
-            "num_docs": params.pop("num_docs", None),
-        }
+        num_docs = params.pop("num_docs", None)
 
         bm25_obj = cls(**params)
-        bm25_obj.scores = scores
         bm25_obj.vocab_dict = vocab_dict
         bm25_obj._original_version = original_version
+
+        bm25_obj.load_scores(
+            save_dir=save_dir,
+            data_name=data_name,
+            indices_name=indices_name,
+            indptr_name=indptr_name,
+            mmap=mmap,
+            num_docs=num_docs,
+            allow_pickle=allow_pickle,
+        )
 
         if load_corpus:
             # load the model from the snapshot

--- a/bm25s/__init__.py
+++ b/bm25s/__init__.py
@@ -937,6 +937,7 @@ class BM25:
         load_corpus=False,
         mmap=False,
         allow_pickle=False,
+        load_vocab=True,
     ):
         """
         Load a BM25S index that was saved using the `save` method.
@@ -980,6 +981,10 @@ class BM25:
         allow_pickle : bool
             If True, the arrays will be loaded using pickle. If False, the arrays will be loaded
             in a more efficient format, but they will not be readable by older versions of numpy.
+        
+        load_vocab : bool
+            If True, the vocab dictionary will be loaded from the `vocab_name` file. If False, the vocab dictionary
+            will not be loaded, and the `vocab_dict` attribute of the BM25 object will be set to None.
         """
         if not isinstance(mmap, bool):
             raise ValueError("`mmap` must be a boolean")
@@ -993,10 +998,13 @@ class BM25:
             params: dict = json_functions.loads(f.read())
 
         # Load the vocab dictionary
-        vocab_path = save_dir / vocab_name
-        with open(vocab_path, "r") as f:
-            vocab_dict: dict = json_functions.loads(f.read())
-
+        if load_vocab:
+            vocab_path = save_dir / vocab_name
+            with open(vocab_path, "r") as f:
+                vocab_dict: dict = json_functions.loads(f.read())
+        else:
+            vocab_dict = None
+        
         original_version = params.pop("version", None)
         num_docs = params.pop("num_docs", None)
 

--- a/bm25s/utils/benchmark.py
+++ b/bm25s/utils/benchmark.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 import time
-
+import sys
 
 try:
     import resource
@@ -16,6 +16,11 @@ def get_max_memory_usage(format="GB"):
         raise ValueError("format should be one of 'GB', 'MB', 'KB'")
 
     usage_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    # for mac, ru_maxrss is in bytes
+    
+    if sys.platform == "darwin":
+        usage_kb /= 1024
+    
     if format == "GB":
         return usage_kb / (1024**2)
     elif format == "MB":

--- a/examples/index_nq.py
+++ b/examples/index_nq.py
@@ -6,7 +6,7 @@ This shows how to build an index of the natural questions dataset using BM25S.
 To run this example, you need to install the following dependencies:
 
 ```bash
-pip install beir bm25s PyStemmer
+pip install bm25s[core]
 ```
 
 Then, run with:
@@ -15,19 +15,18 @@ Then, run with:
 python examples/index_nq.py
 ```
 """
-import beir.util
-from beir.datasets.data_loader import GenericDataLoader
-import Stemmer  # from PyStemmer
 
 import bm25s
-from bm25s.utils.beir import BASE_URL
+import Stemmer
 
 
 def main(save_dir="datasets", index_dir="bm25s_indices/nq", dataset="nq"):
-    data_path = beir.util.download_and_unzip(BASE_URL.format(dataset), save_dir)
-    corpus, _, __ = GenericDataLoader(data_folder=data_path).load(split="test")
+    print("Downloading the dataset...")
+    bm25s.utils.beir.download_dataset(dataset, save_dir=save_dir)
+    print("Loading the corpus...")
+    corpus = bm25s.utils.beir.load_corpus(dataset, save_dir=save_dir)
     corpus_records = [
-        {'id': k, 'title': v["title"], 'text': v["text"]} for k, v in corpus.items()
+        {"id": k, "title": v["title"], "text": v["text"]} for k, v in corpus.items()
     ]
     corpus_lst = [r["title"] + " " + r["text"] for r in corpus_records]
 
@@ -36,7 +35,13 @@ def main(save_dir="datasets", index_dir="bm25s_indices/nq", dataset="nq"):
 
     retriever = bm25s.BM25(corpus=corpus_records)
     retriever.index(corpus_tokenized)
+    print("Created BM25 index.")
     retriever.save(index_dir)
+    print(f"Saved the index to {index_dir}.")
+    # get memory usage
+    mem_use = bm25s.utils.benchmark.get_max_memory_usage()
+    print(f"Peak memory usage: {mem_use:.2f} GB")
+
 
 if __name__ == "__main__":
     main()

--- a/examples/index_nq.py
+++ b/examples/index_nq.py
@@ -16,11 +16,15 @@ python examples/index_nq.py
 ```
 """
 
+from pathlib import Path
 import bm25s
 import Stemmer
 
 
-def main(save_dir="datasets", index_dir="bm25s_indices/nq", dataset="nq"):
+def main(save_dir="datasets", index_dir="bm25s_indices/", dataset="nq"):
+    index_dir = Path(index_dir) / dataset
+    index_dir.mkdir(parents=True, exist_ok=True)
+    
     print("Downloading the dataset...")
     bm25s.utils.beir.download_dataset(dataset, save_dir=save_dir)
     print("Loading the corpus...")

--- a/examples/index_nq.py
+++ b/examples/index_nq.py
@@ -35,17 +35,21 @@ def main(save_dir="datasets", index_dir="bm25s_indices/", dataset="nq"):
     corpus_lst = [r["title"] + " " + r["text"] for r in corpus_records]
 
     stemmer = Stemmer.Stemmer("english")
-    corpus_tokenized = bm25s.tokenize(corpus_lst, stemmer=stemmer)
+    tokenizer = bm25s.tokenization.Tokenizer(stemmer=stemmer)
+    corpus_tokens = tokenizer.tokenize(corpus_lst, return_as="tuple")
 
-    retriever = bm25s.BM25(corpus=corpus_records)
-    retriever.index(corpus_tokenized)
-    print("Created BM25 index.")
+    retriever = bm25s.BM25(corpus=corpus_records, backend="numba")
+    retriever.index(corpus_tokens)
+    
     retriever.save(index_dir)
+    tokenizer.save_vocab(index_dir)
+    tokenizer.save_stopwords(index_dir)
     print(f"Saved the index to {index_dir}.")
+    
     # get memory usage
     mem_use = bm25s.utils.benchmark.get_max_memory_usage()
     print(f"Peak memory usage: {mem_use:.2f} GB")
 
 
 if __name__ == "__main__":
-    main()
+    main(dataset='msmarco')

--- a/examples/retrieve_nq.py
+++ b/examples/retrieve_nq.py
@@ -30,15 +30,16 @@ import Stemmer
 from tqdm import tqdm
 
 
-def main(index_dir="bm25s_indices/nq", data_dir="datasets", dataset="nq", mmap=True):
+def main(index_dir="bm25s_indices/nq", data_dir="datasets", dataset="nq", split="test", mmap=True):
     if mmap:
         print("Using memory-mapped index (mmap) to reduce memory usage.")
 
     timer = bm25s.utils.benchmark.Timer("[BM25S]")
 
-    print("Loading the queries...")
     queries = bm25s.utils.beir.load_queries(dataset, save_dir=data_dir)
-    queries_lst = [q["text"] for q in queries.values()]
+    qrels = bm25s.utils.beir.load_qrels(dataset, split=split, save_dir=data_dir)
+    queries_lst = [v["text"] for k, v in queries.items() if k in qrels]
+    print(f"Loaded {len(queries_lst)} queries.")
 
     # Tokenize the queries
     stemmer = Stemmer.Stemmer("english")

--- a/examples/retrieve_nq.py
+++ b/examples/retrieve_nq.py
@@ -24,13 +24,16 @@ python examples/retrieve_nq.py
 ```
 """
 
+from pathlib import Path
 import numpy as np
 import bm25s
 import Stemmer
 from tqdm import tqdm
 
 
-def main(index_dir="bm25s_indices/nq", data_dir="datasets", dataset="nq", split="test", mmap=True):
+def main(index_dir="bm25s_indices", data_dir="datasets", dataset="nq", split="test", mmap=True):
+    index_dir = Path(index_dir) / dataset
+    
     if mmap:
         print("Using memory-mapped index (mmap) to reduce memory usage.")
 

--- a/examples/retrieve_nq.py
+++ b/examples/retrieve_nq.py
@@ -7,7 +7,7 @@ the top-k results for a set of queries from the Natural Questions dataset, via B
 To run this example, you need to install the following dependencies:
 
 ```bash
-pip install beir bm25s[full]
+pip install bm25s[core]
 ```
 
 To build an index, please refer to the `examples/index_nq.py` script. You
@@ -23,34 +23,55 @@ Then, run this script with:
 python examples/retrieve_nq.py
 ```
 """
-import beir.util
-from beir.datasets.data_loader import GenericDataLoader
-import Stemmer
 
+import numpy as np
 import bm25s
-from bm25s.utils.beir import BASE_URL
+import Stemmer
+from tqdm import tqdm
+
 
 def main(index_dir="bm25s_indices/nq", data_dir="datasets", dataset="nq", mmap=True):
     if mmap:
         print("Using memory-mapped index (mmap) to reduce memory usage.")
-    
-    # Load the queries from BEIR
-    data_path = beir.util.download_and_unzip(BASE_URL.format(dataset), data_dir)
-    loader = GenericDataLoader(data_folder=data_path)
-    loader._load_queries()
-    queries_lst = list(loader.queries.values())[:1000]
+
+    timer = bm25s.utils.benchmark.Timer("[BM25S]")
+
+    print("Loading the queries...")
+    queries = bm25s.utils.beir.load_queries(dataset, save_dir=data_dir)
+    queries_lst = [q["text"] for q in queries.values()]
 
     # Tokenize the queries
     stemmer = Stemmer.Stemmer("english")
-    queries_tokenized = bm25s.tokenize(queries_lst, stemmer=stemmer)
+    queries_tokenized = bm25s.tokenize(queries_lst, stemmer=stemmer, return_ids=False)
+
+    mem_use = bm25s.utils.benchmark.get_max_memory_usage()
+    print(f"Initial memory usage: {mem_use:.2f} GB")
 
     # Load the BM25 index and retrieve the top-k results
+    print("Loading the BM25 index...")
+    t = timer.start("Loading index")
     retriever = bm25s.BM25.load(index_dir, mmap=mmap, load_corpus=True)
-    results = retriever.retrieve(queries_tokenized, k=20)
-    
+    retriever.backend = "numba"
+    num_docs = retriever.scores['num_docs']
+    timer.stop(t, show=True, n_total=num_docs)
+
+    mem_use = bm25s.utils.benchmark.get_max_memory_usage()
+    print(f"Memory usage after loading the index: {mem_use:.2f} GB")
+
+    print("Retrieving the top-k results...")
+    t = timer.start("Retrieving")
+    results = retriever.retrieve(queries_tokenized, k=10)
+    timer.stop(t, show=True, n_total=len(queries_lst))
+
+    # get memory usage
+    mem_use = bm25s.utils.benchmark.get_max_memory_usage()
+    print(f"Final (peak) memory usage: {mem_use:.2f} GB")
+
+    print("-" * 50)
     first_result = results.documents[0]
-    print(f"First score (# 1 result):{results.scores[0, 0]}")
+    print(f"First score (# 1 result): {results.scores[0, 0]:.4f}")
     print(f"First result (# 1 result):\n{first_result[0]}")
 
+
 if __name__ == "__main__":
-    main()
+    main(mmap=True)

--- a/examples/retrieve_nq_with_batching.py
+++ b/examples/retrieve_nq_with_batching.py
@@ -36,9 +36,10 @@ def main(index_dir="bm25s_indices/nq", data_dir="datasets", dataset="nq", bsize=
 
     timer = bm25s.utils.benchmark.Timer("[BM25S]")
 
-    print("Loading the queries...")
     queries = bm25s.utils.beir.load_queries(dataset, save_dir=data_dir)
-    queries_lst = [q["text"] for q in queries.values()]
+    qrels = bm25s.utils.beir.load_qrels(dataset, split="test", save_dir=data_dir)
+    queries_lst = [v["text"] for k, v in queries.items() if k in qrels]
+    print(f"Loaded {len(queries_lst)} queries.")
 
     # Tokenize the queries
     stemmer = Stemmer.Stemmer("english")

--- a/examples/retrieve_nq_with_batching.py
+++ b/examples/retrieve_nq_with_batching.py
@@ -25,12 +25,14 @@ python examples/retrieve_nq.py
 ```
 """
 
+from pathlib import Path
 import bm25s
 import Stemmer
 from tqdm import tqdm
 
 
-def main(index_dir="bm25s_indices/nq", data_dir="datasets", dataset="nq", split="test", bsize=20):
+def main(index_dir="bm25s_indices/", data_dir="datasets", dataset="nq", split="test", bsize=20):
+    index_dir = Path(index_dir) / dataset
     mmap = True
     print("Using memory-mapped index (mmap) to reduce memory usage.")
 

--- a/examples/retrieve_nq_with_batching.py
+++ b/examples/retrieve_nq_with_batching.py
@@ -30,14 +30,14 @@ import Stemmer
 from tqdm import tqdm
 
 
-def main(index_dir="bm25s_indices/nq", data_dir="datasets", dataset="nq", bsize=20):
+def main(index_dir="bm25s_indices/nq", data_dir="datasets", dataset="nq", split="test", bsize=20):
     mmap = True
     print("Using memory-mapped index (mmap) to reduce memory usage.")
 
     timer = bm25s.utils.benchmark.Timer("[BM25S]")
 
     queries = bm25s.utils.beir.load_queries(dataset, save_dir=data_dir)
-    qrels = bm25s.utils.beir.load_qrels(dataset, split="test", save_dir=data_dir)
+    qrels = bm25s.utils.beir.load_qrels(dataset, split=split, save_dir=data_dir)
     queries_lst = [v["text"] for k, v in queries.items() if k in qrels]
     print(f"Loaded {len(queries_lst)} queries.")
 

--- a/examples/retrieve_nq_with_batching.py
+++ b/examples/retrieve_nq_with_batching.py
@@ -1,0 +1,89 @@
+"""
+# Example: Retrieve from pre-built index of Natural Questions
+
+This is a modified version of the `examples/retrieve_nq.py` script that uses batching to
+even reduce memory usage further. This script loads the queries in batches and retrieves
+the top-k results for each batch, clearing the memory after each batch.
+
+To run this example, you need to install the following dependencies:
+
+```bash
+pip install bm25s[core]
+```
+
+To build an index, please refer to the `examples/index_nq.py` script. You
+can run this script with:
+
+```bash
+python examples/index_nq.py
+```
+
+Then, run this script with:
+
+```bash
+python examples/retrieve_nq.py
+```
+"""
+
+import bm25s
+import Stemmer
+from tqdm import tqdm
+
+
+def main(index_dir="bm25s_indices/nq", data_dir="datasets", dataset="nq", bsize=20):
+    mmap = True
+    print("Using memory-mapped index (mmap) to reduce memory usage.")
+
+    timer = bm25s.utils.benchmark.Timer("[BM25S]")
+
+    print("Loading the queries...")
+    queries = bm25s.utils.beir.load_queries(dataset, save_dir=data_dir)
+    queries_lst = [q["text"] for q in queries.values()]
+
+    # Tokenize the queries
+    stemmer = Stemmer.Stemmer("english")
+    queries_tokenized = bm25s.tokenize(queries_lst, stemmer=stemmer, return_ids=False)
+
+    mem_use = bm25s.utils.benchmark.get_max_memory_usage()
+    print(f"Initial memory usage: {mem_use:.2f} GB")
+
+    # Load the BM25 index and retrieve the top-k results
+    print("Loading the BM25 index...")
+    t = timer.start("Loading index")
+    retriever = bm25s.BM25.load(index_dir, mmap=mmap, load_corpus=True)
+    retriever.backend = "numba"
+    num_docs = retriever.scores["num_docs"]
+    timer.stop(t, show=True, n_total=num_docs)
+
+    mem_use = bm25s.utils.benchmark.get_max_memory_usage()
+    print(f"Memory usage after loading the index: {mem_use:.2f} GB")
+
+    print("Retrieving the top-k results...")
+    t = timer.start("Retrieving")
+
+    batches = []
+
+    for i in tqdm(range(0, len(queries_lst), bsize)):
+        batches.append(retriever.retrieve(queries_tokenized[i : i + bsize], k=10))
+        
+        # reload the corpus and scores to free up memory
+        retriever.load_scores(save_dir=index_dir, mmap=mmap, num_docs=num_docs)
+        if isinstance(retriever.corpus, bm25s.utils.corpus.JsonlCorpus):
+            retriever.corpus.load()
+
+    results = bm25s.Results.merge(batches)
+
+    timer.stop(t, show=True, n_total=len(queries_lst))
+
+    # get memory usage
+    mem_use = bm25s.utils.benchmark.get_max_memory_usage()
+    print(f"Final (peak) memory usage: {mem_use:.2f} GB")
+
+    print("-" * 50)
+    first_result = results.documents[0]
+    print(f"First score (# 1 result): {results.scores[0, 0]:.4f}")
+    print(f"First result (# 1 result):\n{first_result[0]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Improve README with example of memory usage optimization
- Add a `Results.merge` method allowing merging list of results
- Make `get_max_memory_usage` compatible with mac os
- Refactor `examples/index_nq.py` to use numba, new tokenizer, simplify loading dataset
- Refactor `examples/retrieve_nq.py` to use numba, and to record memory usage
- Create `examples/retrieve_nq_with_batching.py` which is a batched version of retrieval that clears memory after every use
- 