### PR TITLE
Fix crash tokenizing with empty word_to_id

### DIFF
--- a/bm25s/tokenization.py
+++ b/bm25s/tokenization.py
@@ -273,7 +273,7 @@ class Tokenizer:
 
             if len(doc_ids) == 0 and allow_empty is True:
                 if update_vocab is True and "" not in self.word_to_id:
-                    self.word_to_id[""] = max(self.word_to_id.values()) + 1
+                    self.word_to_id[""] = max(self.word_to_id.values(), default=0) + 1
                 
                 # get the ID for the empty string
                 if "" in self.word_to_id:


### PR DESCRIPTION
When the tokenizer is created without any tokens, `word_to_id` is empty, so the `max` call crashes.

This change adds a default of `0` so that the assigned `id` is `1` as intended.


BTW, it seems like this insertion will cause the word and stem ids to be out of sync. I did not fix that.