### PR TITLE
Update corpus.py

### DIFF
--- a/bm25s/utils/corpus.py
+++ b/bm25s/utils/corpus.py
@@ -27,7 +27,8 @@ def change_extension(path, new_extension):
 def find_newline_positions(path, show_progress=True, leave_progress=True):
     path = str(path)
     indexes = []
-    with open(path, "r") as f:
+    # With UTF-8 encoding, we can solve problems in other languages. It would probably be good to update all open() calls.
+    with open(path, "r", encoding='utf-8') as f:
         indexes.append(f.tell())
         pbar = tqdm(
             total=os.path.getsize(path),


### PR DESCRIPTION
The issue with non-ASCII and UTF-8 characters was partially resolved by updating a single open() call within the find_newline_positions function to include encoding='utf-8'. This update ensures proper handling of multilingual text for the specific operation. However, it is recommended to review and update all instances of open() across the codebase to include encoding='utf-8' for consistency and to prevent similar issues in other functions.