### PR TITLE
fix: raise ValueError when the corpus size is less than k

### DIFF
--- a/bm25s/selection.py
+++ b/bm25s/selection.py
@@ -50,6 +50,12 @@ def topk(query_scores, k, backend="auto", sorted=True):
     This function is used to retrieve the top-k results for a single query. It will only work
     on a 1-dimensional array of scores.
     """
+    if k > len(query_scores):
+        raise ValueError(
+            f"k of {k} is larger than the number of available scores"
+            f", which is {len(query_scores)} (corpus size should be larger than top-k)."
+            f" Please set with a smaller k or increase the size of corpus."
+        )
     if backend == "auto":
         # if jax.lax is available, use it to speed up selection, otherwise use numpy
         backend = "jax" if JAX_IS_AVAILABLE else "numpy"

--- a/tests/core/test_topk.py
+++ b/tests/core/test_topk.py
@@ -63,5 +63,21 @@ class TestTopKSingleQuery(unittest.TestCase):
         
         JAX_IS_AVAILABLE = original_jax_is_available  # Restore the original value
 
+    def test_top_k_with_very_small_corpus(self):
+        # suppose corpus is very small hence the small query_scores
+        query_scores = np.array([0.5, 0.2])
+        # suppose k > len(query_scores)
+        k = 10
+        with self.assertRaises(ValueError) as context:
+            topk(query_scores, k)
+        exception_str_should_include = "Please set with a smaller k or increase the size of corpus."
+        self.assertIn(
+            exception_str_should_include,
+            str(context.exception),
+            f"Expected ValueError mentioning (but did not)"
+            f"; {exception_str_should_include}"
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi! attached please find the possible fix for issue #116 

I must say it was very enjoyable to read through your codes to learn the style of your codes in the repository! Elegant indeed.

### Summary
Added a check for the value of k where it raises a `ValueError` when `k > len(query_scores)` and the related tester as a counterpart.

### Details
- `bm25s/selection.py`: Added `if k > len(query_scores): raise ValueError(...)`
- `tests/core/test_topk.py`: Added new test to raise the ValueError with the specific message so that the user may not be confused by the numpy out of bound error message.

### Some more details
The minimal reproduction code that I have used for the issue #116 was as follows, using the examples in the repository.
```python
import bm25s
print("Package Source: ", bm25s.__file__)

corpus = [
    "a cat is a feline and likes to purr",
    "a dog is the human's best friend and loves to play",
    "a bird is a beautiful animal that can fly",
    "a fish is a creature that lives in water and swims",
]
index_dir = "./test_index"
query = "is cat cuter than dog?"
top_k_safe = 5
top_k_unsafe = 10

corpus_tokens = bm25s.tokenize(corpus, stopwords="en")
corpus = [{"id": i, "text": doc} for i, doc in enumerate(corpus)]
retriever = bm25s.BM25()
retriever.index(corpus_tokens)
print(f"[Saving] BM25 index into {index_dir}")
retriever.save(save_dir=index_dir, corpus=corpus)

retriever = bm25s.BM25.load(save_dir=index_dir,
                            load_corpus=True)
query_tokens = bm25s.tokenize(query)

print("Trying; [Safe]")
results, scores = retriever.retrieve(
    query_tokens, k=top_k_safe
)
print(f"[Safe] Worked for; {results} with {scores}")

print("Trying; [Unsafe]")
results, scores = retriever.retrieve(
    query_tokens, k=top_k_unsafe
)
```