### PR TITLE
Truncated Printing of the Tokenization Results for issue #90

### DIFF
--- a/bm25s/tokenization.py
+++ b/bm25s/tokenization.py
@@ -113,49 +113,6 @@ class Tokenized(NamedTuple):
         return "\n".join(lines)
 
 
-class CorpusIDsList(list):
-    def __repr__(self):
-        """
-        Returns:
-            a string representation of the class.
-            for example, for a small corpus, it would be something like:
-            ----
-            CorpusIDsList(
-              0: [cat, feline, likes, purr]
-            )
-            ----
-
-            and, for example, for a large corpus, it would be something like:
-            ----
-            CorpusIDsList(
-              0: [cat, feline, likes, purr]
-              1: [dog, human, best, friend, loves, play]
-              2: [bird, beautiful, animal, can, fly]
-              3: [fish, creature, lives, water, swims]
-              4: [cat, feline, likes, purr, cat, may, like, jump, very, high, ...]
-              5: [cat, feline, likes, purr]
-              6: [dog, human, best, friend, loves, play]
-              7: [bird, beautiful, animal, can, fly]
-              8: [fish, creature, lives, water, swims]
-              9: [cat, feline, likes, purr, cat, may, like, jump, very, high, ...]
-              ... (total 500000 docs)
-            )
-            ----
-        """
-        lines_print_max_num = 10
-        single_doc_print_max_len = 10
-        lines = ["CorpusIDsList("]
-        for doc_idx, document in enumerate(self[:lines_print_max_num]):
-            preview = document[:single_doc_print_max_len]
-            if len(document) > single_doc_print_max_len:
-                preview = preview + ["..."]
-            lines.append(f"  {doc_idx}: [{', '.join([str(x) for x in preview])}]")
-        if len(self) > lines_print_max_num:
-            lines.append(f"  ... (total {len(self)} docs)")
-        lines.append(")")
-        return "\n".join(lines)
-
-
 class Tokenizer:
     """
     Tokenizer class for tokenizing a list of strings and converting them to token IDs.
@@ -748,4 +705,4 @@ def tokenize(
             )
         ):
             corpus_ids[i] = [reverse_dict[token_id] for token_id in token_ids]
-        return CorpusIDsList(corpus_ids)
+        return corpus_ids

--- a/bm25s/tokenization.py
+++ b/bm25s/tokenization.py
@@ -40,6 +40,121 @@ class Tokenized(NamedTuple):
     ids: List[List[int]]
     vocab: Dict[str, int]
 
+    def __repr__(self):
+        """
+        Returns:
+            a string representation of the class.
+            for example, for a small corpus, it would be something like:
+            ----
+            Tokenized(
+              "ids": [
+                0: [0, 1, 2, 3]
+              ],
+              "vocab": [
+                '': 4
+                'cat': 0
+                'feline': 1
+                'likes': 2
+                'purr': 3
+              ],
+            )
+            ----
+
+            and, for example, for a large corpus, it would be something like:
+            ----
+            Tokenized(
+              "ids": [
+                0: [0, 1, 2, 3]
+                1: [4, 5, 6, 7, 8, 9]
+                2: [10, 11, 12, 13, 14]
+                3: [15, 16, 17, 18, 19]
+                4: [0, 1, 2, 3, 0, 20, 21, 22, 23, 24, ...]
+                5: [0, 1, 2, 3]
+                6: [4, 5, 6, 7, 8, 9]
+                7: [10, 11, 12, 13, 14]
+                8: [15, 16, 17, 18, 19]
+                9: [0, 1, 2, 3, 0, 20, 21, 22, 23, 24, ...]
+                ... (total 500000 docs)
+              ],
+              "vocab": [
+                '': 29
+                'animal': 12
+                'beautiful': 11
+                'best': 6
+                'bird': 10
+                'can': 13
+                'carefully': 27
+                'casually': 28
+                'cat': 0
+                'creature': 16
+                ... (total 30 tokens)
+              ],
+            )
+            ----
+        """
+        lines_print_max_num = 10
+        single_doc_print_max_len = 10
+        lines = ["Tokenized(", '  "ids": [']
+        for doc_idx, document in enumerate(self.ids[:lines_print_max_num]):
+            preview = document[:single_doc_print_max_len]
+            if len(document) > single_doc_print_max_len:
+                preview += ["..."]
+            lines.append(f"    {doc_idx}: [{', '.join([str(x) for x in preview])}]")
+        if len(self.ids) > lines_print_max_num:
+            lines.append(f"    ... (total {len(self.ids)} docs)")
+        lines.append(f'  ],\n  "vocab": [')
+        vocab_keys = sorted(list(self.vocab.keys()))
+        for vocab_idx, key_ in enumerate(vocab_keys[:lines_print_max_num]):
+            val_ = self.vocab[key_]
+            lines.append(f"    {key_!r}: {val_}")
+        if len(list(vocab_keys)) > 10:
+            lines.append(f"    ... (total {len(vocab_keys)} tokens)")
+        lines.append("  ],\n)")
+        return "\n".join(lines)
+
+
+class CorpusIDsList(list):
+    def __repr__(self):
+        """
+        Returns:
+            a string representation of the class.
+            for example, for a small corpus, it would be something like:
+            ----
+            CorpusIDsList(
+              0: [cat, feline, likes, purr]
+            )
+            ----
+
+            and, for example, for a large corpus, it would be something like:
+            ----
+            CorpusIDsList(
+              0: [cat, feline, likes, purr]
+              1: [dog, human, best, friend, loves, play]
+              2: [bird, beautiful, animal, can, fly]
+              3: [fish, creature, lives, water, swims]
+              4: [cat, feline, likes, purr, cat, may, like, jump, very, high, ...]
+              5: [cat, feline, likes, purr]
+              6: [dog, human, best, friend, loves, play]
+              7: [bird, beautiful, animal, can, fly]
+              8: [fish, creature, lives, water, swims]
+              9: [cat, feline, likes, purr, cat, may, like, jump, very, high, ...]
+              ... (total 500000 docs)
+            )
+            ----
+        """
+        lines_print_max_num = 10
+        single_doc_print_max_len = 10
+        lines = ["CorpusIDsList("]
+        for doc_idx, document in enumerate(self[:lines_print_max_num]):
+            preview = document[:single_doc_print_max_len]
+            if len(document) > single_doc_print_max_len:
+                preview = preview + ["..."]
+            lines.append(f"  {doc_idx}: [{', '.join([str(x) for x in preview])}]")
+        if len(self) > lines_print_max_num:
+            lines.append(f"  ... (total {len(self)} docs)")
+        lines.append(")")
+        return "\n".join(lines)
+
 
 class Tokenizer:
     """
@@ -620,7 +735,6 @@ def tokenize(
     # Step 3: Return the tokenized IDs and the vocab dictionary or the tokenized strings
     if return_ids:
         return Tokenized(ids=corpus_ids, vocab=vocab_dict)
-
     else:
         # We need a reverse dictionary to convert the token IDs back to tokens
         reverse_dict = stem_id_to_stem if stemmer is not None else unique_tokens
@@ -634,5 +748,4 @@ def tokenize(
             )
         ):
             corpus_ids[i] = [reverse_dict[token_id] for token_id in token_ids]
-
-        return corpus_ids
+        return CorpusIDsList(corpus_ids)

--- a/tests/core/test_tokenizer_misc.py
+++ b/tests/core/test_tokenizer_misc.py
@@ -156,32 +156,16 @@ class TestBM25SNewIds(unittest.TestCase):
             corpus += small_unit
         tokenized = bm25s.tokenize(corpus, stopwords="en", return_ids=True)
         repr_tokenized = repr(tokenized)
-        self.assertEqual(repr_tokenized, str(tokenized))
         self.assertIn("... (total", repr_tokenized,
                       msg="it should include the '...' message, for the indication of the truncation.")
         self.assertIn(", ...]", repr_tokenized,
                       msg="it should include the '...' message, for the indication of the truncation.")
-        corpus_ids = bm25s.tokenize(corpus, stopwords="en", return_ids=False)
-        repr_corpus_ids = repr(corpus_ids)
-        self.assertEqual(repr_corpus_ids, str(repr_corpus_ids))
-        self.assertIn("... (total", repr_corpus_ids,
-                      msg="it should include the '...' message within the token id list, for the same reason.")
-        self.assertIn(", ...]", repr_corpus_ids,
-                      msg="it should include the '...' message within the token id list, for the same reason.")
 
     def test_truncation_of_small_corpus(self):
         corpus = ["a cat is a feline"]
         tokenized = bm25s.tokenize(corpus, stopwords="en", return_ids=True)
         repr_tokenized = repr(tokenized)
-        self.assertEqual(repr_tokenized, str(tokenized))
         self.assertNotIn("... (total", repr_tokenized,
                          msg="it should not include the '...' message when the corpus is small")
         self.assertNotIn(", ...]", repr_tokenized,
-                         msg="it should not include the '...' message when the doc is short")
-        corpus_ids = bm25s.tokenize(corpus, stopwords="en", return_ids=False)
-        repr_corpus_ids = repr(corpus_ids)
-        self.assertEqual(repr_corpus_ids, str(repr_corpus_ids))
-        self.assertNotIn("... (total", repr_corpus_ids,
-                         msg="it should not include the '...' message when the corpus is small")
-        self.assertNotIn(", ...]", repr_corpus_ids,
                          msg="it should not include the '...' message when the doc is short")

--- a/tests/core/test_tokenizer_misc.py
+++ b/tests/core/test_tokenizer_misc.py
@@ -141,3 +141,47 @@ class TestBM25SNewIds(unittest.TestCase):
 
         results, scores = bm25.retrieve(query_tokens, k=3)
         self.assertTrue(np.all(scores == 0.0))
+
+    def test_truncation_of_large_corpus(self):
+        small_unit = [
+            "a cat is a feline and likes to purr",
+            "a dog is the human's best friend and loves to play",
+            "a bird is a beautiful animal that can fly",
+            "a fish is a creature that lives in water and swims",
+            # a line more than 10 tokens
+            "a cat is a feline and likes to purr and the cat can jump very high with so careful but casual manner",
+        ]
+        corpus = []
+        for i in range(1000):
+            corpus += small_unit
+        tokenized = bm25s.tokenize(corpus, stopwords="en", return_ids=True)
+        repr_tokenized = repr(tokenized)
+        self.assertEqual(repr_tokenized, str(tokenized))
+        self.assertIn("... (total", repr_tokenized,
+                      msg="it should include the '...' message, for the indication of the truncation.")
+        self.assertIn(", ...]", repr_tokenized,
+                      msg="it should include the '...' message, for the indication of the truncation.")
+        corpus_ids = bm25s.tokenize(corpus, stopwords="en", return_ids=False)
+        repr_corpus_ids = repr(corpus_ids)
+        self.assertEqual(repr_corpus_ids, str(repr_corpus_ids))
+        self.assertIn("... (total", repr_corpus_ids,
+                      msg="it should include the '...' message within the token id list, for the same reason.")
+        self.assertIn(", ...]", repr_corpus_ids,
+                      msg="it should include the '...' message within the token id list, for the same reason.")
+
+    def test_truncation_of_small_corpus(self):
+        corpus = ["a cat is a feline"]
+        tokenized = bm25s.tokenize(corpus, stopwords="en", return_ids=True)
+        repr_tokenized = repr(tokenized)
+        self.assertEqual(repr_tokenized, str(tokenized))
+        self.assertNotIn("... (total", repr_tokenized,
+                         msg="it should not include the '...' message when the corpus is small")
+        self.assertNotIn(", ...]", repr_tokenized,
+                         msg="it should not include the '...' message when the doc is short")
+        corpus_ids = bm25s.tokenize(corpus, stopwords="en", return_ids=False)
+        repr_corpus_ids = repr(corpus_ids)
+        self.assertEqual(repr_corpus_ids, str(repr_corpus_ids))
+        self.assertNotIn("... (total", repr_corpus_ids,
+                         msg="it should not include the '...' message when the corpus is small")
+        self.assertNotIn(", ...]", repr_corpus_ids,
+                         msg="it should not include the '...' message when the doc is short")


### PR DESCRIPTION
Hi! Attached please find the possible fix for issue #90 

Thank you for considering my submission, and I truly appreciate it.

## Summary
Added `__repr__` method for `Tokenized` class at `bm25s/tokenization.py` ,

and added `CorpusIDsList` class that inherits the built in class of python `list`,

in order to make the printing of the tokenization results of the large corpus as follows.

### `return_ids=True`
```text
Tokenized(
  "ids": [
    0: [0, 1, 2, 3]
    1: [4, 5, 6, 7, 8, 9]
    2: [10, 11, 12, 13, 14]
    3: [15, 16, 17, 18, 19]
    4: [0, 1, 2, 3, 0, 20, 21, 22, 23, 24, ...]
    5: [0, 1, 2, 3]
    6: [4, 5, 6, 7, 8, 9]
    7: [10, 11, 12, 13, 14]
    8: [15, 16, 17, 18, 19]
    9: [0, 1, 2, 3, 0, 20, 21, 22, 23, 24, ...]
    ... (total 500000 docs)
  ],
  "vocab": [
: 29
    'animal': 12
    'beautiful': 11
    'best': 6
    'bird': 10
    'can': 13
    'carefully': 27
    'casually': 28
    'cat': 0
    'creature': 16
    ... (total 30 tokens)
  ],
)
```

### `return_ids=False`
```text
CorpusIDsList(
  0: [cat, feline, likes, purr]
  1: [dog, human, best, friend, loves, play]
  2: [bird, beautiful, animal, can, fly]
  3: [fish, creature, lives, water, swims]
  4: [cat, feline, likes, purr, cat, may, like, jump, very, high, ...]
  5: [cat, feline, likes, purr]
  6: [dog, human, best, friend, loves, play]
  7: [bird, beautiful, animal, can, fly]
  8: [fish, creature, lives, water, swims]
  9: [cat, feline, likes, purr, cat, may, like, jump, very, high, ...]
  ... (total 500000 docs)
)
```


## Details
### `bm25s/tokenization.py`
#### `return_ids=True`
At `Tokenized` class, added `__repr__` that can print the pretty output. It was inspired from the examples of pandas’ DataFrame or HuggingFace’s truncated output of tensors. The package pandas uses some formatting helpers to set each of the lines. I tried to implement such methods, but for current purpose, the helper module was deemed possibly excessive; hence the current version. I reckoned that I would use tab instead of the spaces, but thought that spaces would be better for uniform representation over diverse environments.

#### `return_ids=False`
Added a new class `CorpusIDsList` that extends Python's native list, so that the returned types would be consistent. The name was chosen, following the original return values, for the coherence of the reading.

### `tests/core/test_tokenizer_misc.py`
Added tests (`test_truncation_of_large_corpus` and `test_truncation_of_small_corpus`), in order to check the marker of truncation `, ...]` or `... (total`.

## Some more details
The reproduction code that I have used for the issue was as follows, using the examples in the original readme.
```text
import bm25s
import Stemmer

corpus_very_small = [
    "a cat is a feline and likes to purr",
]

corpus_small = [
    "a cat is a feline and likes to purr",
    "a dog is the human's best friend and loves to play",
    "a bird is a beautiful animal that can fly",
    "a fish is a creature that lives in water and swims",
    # a line more than 10 tokens
    "a cat is a feline and likes to purr and the cat may like to jump very high still so carefully and casually",
]
stemmer = Stemmer.Stemmer("english")
corpus_large = []
for i in range(100000):
    corpus_large += corpus_small

type2corpus = {
    "VERY_SMALL": corpus_very_small,
    "SMALL": corpus_small,
    "LARGE": corpus_large,
}

for corpus_type, target_corpus in type2corpus.items():
    print("*"*30)
    print("-"*30)
    print(f"[CASE] CORPUS={corpus_type} | STEMMER=NONE | RETURN_IDS=TRUE")
    corpus_tokens = bm25s.tokenize(target_corpus, stopwords="en", stemmer=None, return_ids=True)
    retriever = bm25s.BM25()
    retriever.index(corpus_tokens)
    print(corpus_tokens)

    print("-"*30)
    print(f"[CASE] CORPUS={corpus_type} | STEMMER=NONE | RETURN_IDS=FALSE")
    corpus_tokens = bm25s.tokenize(target_corpus, stopwords="en", stemmer=None, return_ids=False)
    retriever = bm25s.BM25()
    retriever.index(corpus_tokens)
    print(corpus_tokens)

    stemmer = Stemmer.Stemmer("english")
    print("-"*30)
    print(f"[CASE] CORPUS={corpus_type} | STEMMER=NAIVE | RETURN_IDS=TRUE")
    corpus_tokens = bm25s.tokenize(target_corpus, stopwords="en", stemmer=stemmer, return_ids=True)
    retriever = bm25s.BM25()
    retriever.index(corpus_tokens)
    print(corpus_tokens)

    print("-"*30)
    print(f"[CASE] CORPUS={corpus_type} | STEMMER=NAIVE | RETURN_IDS=FALSE")
    corpus_tokens = bm25s.tokenize(target_corpus, stopwords="en", stemmer=stemmer, return_ids=False)
    retriever = bm25s.BM25()
    retriever.index(corpus_tokens)
    print(corpus_tokens)
```

I have ran the local tests at `tests/core`, to confirm the added lines would not conflict with the original code base. If there are further improvements or alternative approaches you’d prefer, please let me know; I’m happy to edit or modify this further following your feedback, and I am looking forward to it.