### PR TITLE
fix: raise ValueError in retrieve directly, rather than in topk

### DIFF
--- a/bm25s/__init__.py
+++ b/bm25s/__init__.py
@@ -675,6 +675,13 @@ class BM25:
         ImportError
             If the numba backend is selected but numba is not installed.
         """
+        num_docs = self.scores["num_docs"]
+        if k > num_docs:
+            raise ValueError(
+                f"k of {k} is larger than the number of available scores"
+                f", which is {num_docs} (corpus size should be larger than top-k)."
+                f" Please set with a smaller k or increase the size of corpus."
+            )
         allowed_return_as = ["tuple", "documents"]
 
         if return_as not in allowed_return_as:

--- a/bm25s/selection.py
+++ b/bm25s/selection.py
@@ -50,12 +50,6 @@ def topk(query_scores, k, backend="auto", sorted=True):
     This function is used to retrieve the top-k results for a single query. It will only work
     on a 1-dimensional array of scores.
     """
-    if k > len(query_scores):
-        raise ValueError(
-            f"k of {k} is larger than the number of available scores"
-            f", which is {len(query_scores)} (corpus size should be larger than top-k)."
-            f" Please set with a smaller k or increase the size of corpus."
-        )
     if backend == "auto":
         # if jax.lax is available, use it to speed up selection, otherwise use numpy
         backend = "jax" if JAX_IS_AVAILABLE else "numpy"

--- a/tests/core/test_retrieve.py
+++ b/tests/core/test_retrieve.py
@@ -126,9 +126,37 @@ class TestBM25SLoadingSaving(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.retriever.retrieve(query_tokens_tuple, k=2)
 
-        
-
-
+    def test_value_error_for_very_small_corpus(self):
+        query = "a cat is a feline, it's sometimes beautiful but cannot fly"
+        query_tokens = bm25s.tokenize(
+            [query], stopwords="en",
+            stemmer=self.stemmer, return_ids=True
+        )
+        corpus_size = len(self.corpus)
+        for k in range(0, 10):
+            if k > corpus_size:
+                with self.assertRaises(ValueError) as context:
+                    self.retriever.retrieve(query_tokens, k=k)
+                exception_str_should_include =\
+                    "Please set with a smaller k or increase the size of corpus."
+                self.assertIn(
+                    exception_str_should_include,
+                    str(context.exception),
+                    f"[k={k}] Expected ValueError mentioning (but did not)"
+                    f"; {exception_str_should_include}"
+                )
+            else:
+                results, scores = self.retriever.retrieve(query_tokens, k=k)
+                self.assertEqual(
+                    int(results.size), k,
+                    f"[k={k}] The number of searched items"
+                    f" should be {k}; but it was {results.size}"
+                )
+                self.assertEqual(
+                    int(scores.size), k,
+                    f"[k={k}] The number of searched items"
+                    f" should be {k}; but it was {scores.size}"
+                )
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/core/test_topk.py
+++ b/tests/core/test_topk.py
@@ -63,21 +63,6 @@ class TestTopKSingleQuery(unittest.TestCase):
         
         JAX_IS_AVAILABLE = original_jax_is_available  # Restore the original value
 
-    def test_top_k_with_very_small_corpus(self):
-        # suppose corpus is very small hence the small query_scores
-        query_scores = np.array([0.5, 0.2])
-        # suppose k > len(query_scores)
-        k = 10
-        with self.assertRaises(ValueError) as context:
-            topk(query_scores, k)
-        exception_str_should_include = "Please set with a smaller k or increase the size of corpus."
-        self.assertIn(
-            exception_str_should_include,
-            str(context.exception),
-            f"Expected ValueError mentioning (but did not)"
-            f"; {exception_str_should_include}"
-        )
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi! attached please find the follow up for issue #116 and the PR #117.

### Summary
Directly raises a `ValueError` when `k > num_docs_in_corpus`

Move the test method to `test_retrieve.py`.

### Details
- `bm25s/__init__.py`: Added `if k > len(query_scores): raise ValueError(...)` to `retrieve` method
- `tests/core/test_retrieve.py`: moved the previous testing method from `test_topk.py` to it. Testing all the small values of `k`.

If you have any further feedback or suggestions for improvement, please let me know. Thank you again for such a great package.