### PR TITLE
fix: update tokenize docstring to avoid SyntaxWarning - invalid escape sequence \w

### DIFF
--- a/bm25s/tokenization.py
+++ b/bm25s/tokenization.py
@@ -516,7 +516,7 @@ def tokenize(
         Whether to convert the text to lowercase before tokenization
 
     token_pattern : str, optional
-        The regex pattern to use for tokenization, by default r"(?u)\b\w\w+\b"
+        The regex pattern to use for tokenization. r"(?u)\\b\\w\\w+\\b"
 
     stopwords : Union[str, List[str]], optional
         The list of stopwords to remove from the text. If "english" or "en" is provided,

--- a/bm25s/tokenization.py
+++ b/bm25s/tokenization.py
@@ -516,7 +516,7 @@ def tokenize(
         Whether to convert the text to lowercase before tokenization
 
     token_pattern : str, optional
-        The regex pattern to use for tokenization. r"(?u)\\b\\w\\w+\\b"
+        The regex pattern to use for tokenization, by default, r"(?u)\\b\\w\\w+\\b"
 
     stopwords : Union[str, List[str]], optional
         The list of stopwords to remove from the text. If "english" or "en" is provided,


### PR DESCRIPTION
See issue raised here: https://github.com/xhluca/bm25s/issues/123#issue-2929856321

> In the file tokenization.py, line 493, the docstring includes an example of the default regex pattern to use for tokenization. This regex pattern has unescaped backslashes. In Python versions >=3.12, this leads to [a "SyntaxWarning: invalid escape sequence"](https://stackoverflow.com/questions/52335970/how-to-fix-syntaxwarning-invalid-escape-sequence-in-python). [Docstrings are parsed as string literals](https://discuss.python.org/t/please-dont-break-invalid-escape-sequences/74134) in python, and so even though the string is correctly indicated as a literal using the 'r' marking, the SyntaxWarning is still raised.