### PR TITLE
Pass weight_mask through to _retrieve_numba_functional

### DIFF
--- a/bm25s/__init__.py
+++ b/bm25s/__init__.py
@@ -790,6 +790,7 @@ class BM25:
                 dtype=self.dtype,
                 int_dtype=self.int_dtype,
                 nonoccurrence_array=self.nonoccurrence_array,
+                weight_mask=weight_mask,
             )
 
             if return_as == "tuple":


### PR DESCRIPTION
It seems `weight_mask` isn't being passed through to `_retrieve_numba_functional` at the moment (and so is propagated as None within that). 