### PR TITLE
fix merge_cqa_dupstack

### DIFF
--- a/bm25s/utils/beir.py
+++ b/bm25s/utils/beir.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from pathlib import Path
 from typing import Dict, List, Tuple
@@ -66,7 +67,7 @@ def merge_cqa_dupstack(data_path):
                         # add the corpus name to _id
                         line["_id"] = f"{corpus_name}_{line['_id']}"
                         # write back to file
-                        f.write(json_functions.dumps(line))
+                        f.write(json.dumps(line)) # json_functions.dumps generates json that can't be read by beir
                         f.write("\n")
 
     # now, do the same for queries.jsonl


### PR DESCRIPTION
`merge_cqa_dupstack` produces a json corpus that can't be read by `beir` when `orjson` is installed. This PR fixes this problem by using the standard library instead.

(Issue identified in https://github.com/xhluca/bm25-benchmarks/pull/9)