### PR TITLE
Use GitHub release for BEIR dataset downloads

### DIFF
--- a/bm25s/utils/beir.py
+++ b/bm25s/utils/beir.py
@@ -18,8 +18,8 @@ except ImportError:
 
 from . import json_functions
 
-BASE_URL = "https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/{}.zip"
 GH_URL = "https://github.com/xhluca/bm25s/releases/download/data/{}.zip"
+BASE_URL = GH_URL
 
 
 def clean_results_keys(beir_results):
@@ -132,6 +132,7 @@ def download_dataset(
     show_progress=True,
 ):
     import urllib.request
+    import urllib.error
     import zipfile
     from pathlib import Path
     from tqdm.auto import tqdm
@@ -144,20 +145,18 @@ def download_dataset(
     save_zip_path = save_dir / "archive" / f"{dataset}.zip"
     save_zip_path.parent.mkdir(parents=True, exist_ok=True)
 
-    if not save_zip_path.exists() or redownload:
-        # download the zip file and save it with tqdm progress bar
+    def download_file(src_url, dst_path, desc):
         pbar = tqdm(
             unit="B",
             unit_scale=True,
-            desc=f"Downloading {dataset}",
+            desc=desc,
             leave=False,
             disable=not show_progress,
         )
-        with open(save_zip_path, "wb") as f:
-            response = urllib.request.urlopen(url)
+        with open(dst_path, "wb") as f:
+            response = urllib.request.urlopen(src_url)
             total_size = int(response.headers.get("content-length", 0))
             block_size = 8192 * 2
-            # set the tqdm total to the total size
             pbar.total = total_size
             while True:
                 buffer = response.read(block_size)
@@ -167,6 +166,52 @@ def download_dataset(
                 pbar.update(len(buffer))
 
         pbar.close()
+
+    def download_multipart_release(dataset_url, dst_path):
+        part_paths = []
+        for part_idx in range(1000):
+            part_path = dst_path.parent / f"{dst_path.name}.part-{part_idx:03d}"
+            part_url = f"{dataset_url}.part-{part_idx:03d}"
+            try:
+                download_file(
+                    part_url, part_path, f"Downloading {dataset} part {part_idx:03d}"
+                )
+            except urllib.error.HTTPError as exc:
+                if part_path.exists():
+                    part_path.unlink()
+                if exc.code == 404 and part_idx > 0:
+                    break
+                raise
+            part_paths.append(part_path)
+
+        if not part_paths:
+            raise FileNotFoundError(
+                f"No release assets found for dataset {dataset} at {dataset_url}"
+            )
+
+        with open(dst_path, "wb") as f_out:
+            for part_path in tqdm(
+                part_paths,
+                desc=f"Assembling {dataset}",
+                leave=False,
+                disable=not show_progress,
+            ):
+                with open(part_path, "rb") as f_in:
+                    while True:
+                        chunk = f_in.read(8192 * 2)
+                        if not chunk:
+                            break
+                        f_out.write(chunk)
+                part_path.unlink()
+
+    if not save_zip_path.exists() or redownload:
+        try:
+            download_file(url, save_zip_path, f"Downloading {dataset}")
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                download_multipart_release(url, save_zip_path)
+            else:
+                raise
 
     # now that we have the zip file, extract it
     if unzip:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 
 import bm25s
+from bm25s.utils.beir import BASE_URL
 
 
 # Make sure to import or define the functions/classes you're going to use,
@@ -54,10 +55,7 @@ class BM25TestCase(unittest.TestCase):
             raise ValueError("method must be either 'rank' or 'bm25+'.")
 
         # Download and prepare dataset
-        base_url = (
-            "https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/{}.zip"
-        )
-        url = base_url.format(dataset)
+        url = BASE_URL.format(dataset)
         out_dir = Path(__file__).parent / rel_save_dir
         data_path = download_and_unzip(url, str(out_dir))
 
@@ -191,10 +189,7 @@ class BM25TestCase(unittest.TestCase):
         warnings.filterwarnings("ignore", category=UserWarning)
 
         # Download and prepare dataset
-        base_url = (
-            "https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/{}.zip"
-        )
-        url = base_url.format(dataset)
+        url = BASE_URL.format(dataset)
         out_dir = Path(__file__).parent / rel_save_dir
         data_path = download_and_unzip(url, str(out_dir))
 

--- a/tests/comparison/test_bm25s_indexing.py
+++ b/tests/comparison/test_bm25s_indexing.py
@@ -12,6 +12,7 @@ from beir.util import download_and_unzip
 import Stemmer
 
 import bm25s
+from bm25s.utils.beir import BASE_URL
 
 def check_scores_all_close(score1, score2, **kwargs):
     for key in score1.keys():
@@ -36,10 +37,7 @@ class BM25SIndexing(unittest.TestCase):
         dataset = "scifact"
         rel_save_dir = "datasets"
         # Download and prepare dataset
-        base_url = (
-            "https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/{}.zip"
-        )
-        url = base_url.format(dataset)
+        url = BASE_URL.format(dataset)
         out_dir = Path(__file__).parent / rel_save_dir
         data_path = download_and_unzip(url, str(out_dir))
 


### PR DESCRIPTION
## Summary
- switch BEIR dataset URLs from the TU Darmstadt host to the existing GitHub data release
- add multipart release-asset fallback for oversized datasets such as cqadupstack
- update comparison tests to use the shared BEIR release URL

## Release assets updated
- added hotpotqa.zip
- added dbpedia-entity.zip
- added cqadupstack.zip.part-000, cqadupstack.zip.part-001, cqadupstack.zip.part-002

## Verification
- rg found no remaining TU Darmstadt BEIR dataset URLs
- python -m py_compile bm25s/utils/beir.py tests/__init__.py tests/comparison/test_bm25s_indexing.py
- python -m pytest tests/comparison/test_utils_corpus.py -q
- offline smoke test for multipart reassembly