### PR TITLE
Clarify supported corpus formats in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,44 @@ reloaded_retriever = bm25s.BM25.load("animal_index_bm25", load_corpus=True)
 # set load_corpus=False if you don't need the corpus
 ```
 
+### Corpus Format
+
+`bm25s` separates the text you index from the values you get back. Pass
+strings to `bm25s.tokenize()`, then pass the resulting tokenized corpus to
+`retriever.index()`. The optional `corpus` argument on `BM25(...)`,
+`retrieve(...)`, and `save(...)` is the list of values returned for matching
+document IDs.
+
+Both plain strings and dictionaries are valid corpus entries:
+
+```python
+text_corpus = [
+    "a cat is a feline and likes to purr",
+    "a dog is the human's best friend and loves to play",
+]
+
+metadata_corpus = [
+    {"id": "cat-doc", "title": "About Cat", "text": text_corpus[0]},
+    {"id": "dog-doc", "title": "About Dog", "text": text_corpus[1]},
+]
+
+# Pick the text field(s) you want to index.
+corpus_tokens = bm25s.tokenize([doc["text"] for doc in metadata_corpus])
+
+# Retrieved documents will be the original dictionary entries.
+retriever = bm25s.BM25(corpus=metadata_corpus)
+retriever.index(corpus_tokens)
+```
+
+Dictionaries do not have required keys; use the shape that fits your
+application, such as `id`, `title`, `text`, or nested metadata. Retrieval is
+position-based, so `corpus[i]` is returned for document ID `i`. Keep the corpus
+you pass to `BM25(...)`, `retrieve(...)`, or `save(...)` in the same order and
+length as the indexed documents. When saving, entries must be strings,
+dictionaries, lists, or tuples that can be serialized to JSON. String entries
+are written to `corpus.jsonl` as `{"id": i, "text": doc}`; dictionaries, lists,
+and tuples are written as provided.
+
 For an example that shows how to quickly index a 2M-documents corpus (Natural Questions), check out [`examples/index_nq.py`](examples/index_nq.py).
 
 ## High Level API

--- a/bm25s/__init__.py
+++ b/bm25s/__init__.py
@@ -182,10 +182,13 @@ class BM25:
         int_dtype : str
             The data type of the indices in the BM25 scores.
 
-        corpus : Iterable[Dict]
-            The corpus of documents. This is optional and is used for saving the corpus
-            to the snapshot. We expect the corpus to be a list of dictionaries, where each
-            dictionary represents a document.
+        corpus : Iterable[Any], optional
+            Optional corpus entries to keep on the retriever and save with the index.
+            Retrieval returns the corpus entry at the matched document index, and
+            dictionaries do not require any specific keys. If saved, entries must be
+            strings, dictionaries, lists, or tuples that can be serialized to JSON.
+            String entries are serialized as dictionaries with ``id`` and ``text``
+            fields.
 
         backend : str
             The backend used during retrieval. By default, it uses the numpy backend, which
@@ -690,11 +693,13 @@ class BM25:
             List of list of tokens for each query. If a Tokenized object is provided,
             it will be converted to a list of list of tokens.
 
-        corpus : List[str] or np.ndarray
-            List of "documents" or a numpy array of documents. If provided, the function
-            will return the documents instead of the indices. You do not have to provide
-            the original documents (for example, you can provide the unique IDs of the
-            documents here and then retrieve the actual documents from another source).
+        corpus : List[Any] or np.ndarray
+            List or array aligned with the indexed documents. If provided, the function
+            returns ``corpus[i]`` for each retrieved document ID instead of returning the
+            numeric IDs. Entries can be strings, dictionaries, external IDs, or other
+            application objects; dictionaries do not require any specific keys. You do
+            not have to provide the original documents. For example, you can provide
+            unique IDs here and retrieve the actual documents from another source.
 
         k : int
             Number of documents to retrieve for each query.
@@ -953,8 +958,10 @@ class BM25:
         save_dir : str
             The directory where the BM25S index will be saved.
 
-        corpus : List[Dict]
-            The corpus of documents. If provided, it will be saved to the `corpus` file.
+        corpus : Iterable[Any]
+            Corpus entries to save to the `corpus` file. String entries are saved as
+            dictionaries with ``id`` and ``text`` fields. Dictionaries, lists, and
+            tuples are saved as provided, so dictionary keys are user-defined.
 
         corpus_name : str
             The name of the file that will contain the corpus.

--- a/examples/index_with_metadata.py
+++ b/examples/index_with_metadata.py
@@ -1,10 +1,11 @@
 """
-Sometimes, you might want to have a corpus consisting of dict rather than pure text.
+Use dictionary corpus entries when retrieval should return metadata instead of
+plain text.
 
-dicts, and any json-serializable object, is supported by bm25s. This example shows you how to pass a list of dict.
-
-Note: If the elements in your corpus is not json serializable, it will not be properly saved. In those cases, you 
-should avoid passing 
+bm25s indexes by list position: the tokenized text at position i corresponds to
+the corpus entry at position i. Dictionary keys are user-defined. If you save the
+corpus with the index, entries must be strings, dictionaries, lists, or tuples
+that can be serialized to JSON.
 """
 import bm25s
 
@@ -42,7 +43,7 @@ for i in range(results.shape[1]):
     print(f"Rank {i+1} (score: {score:.2f}): {doc}")
 
 # You can save the arrays to a directory...
-# Note that this will fail if your corpus passed to `BM25(corpus...)` is not serializable
+# Note that this will fail if your corpus passed to `BM25(corpus=...)` is not serializable
 retriever.save("animal_index_bm25")
 
 # ...and load them when you need them


### PR DESCRIPTION
## Summary
- add a README section explaining how indexed text maps to returned corpus entries
- clarify that string and dictionary corpus entries are both valid, with dictionary keys defined by the user
- document save/load serialization behavior and tighten the metadata example

Fixes #158

## Testing
- python -m compileall bm25s/__init__.py examples/index_with_metadata.py
- git diff --check