### PR TITLE
Add cupy backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ pip install PyStemmer
 # Install all extra dependencies
 pip install "bm25s[full]"
 
+# For GPU retrieval, install the CuPy package that matches your CUDA runtime,
+# then select backend="cupy" or backend_selection="cupy" explicitly.
+# For example, with CUDA 12:
+pip install cupy-cuda12x
+
 ```
 
 ## Quickstart
@@ -175,6 +180,32 @@ are written to `corpus.jsonl` as `{"id": i, "text": doc}`; dictionaries, lists,
 and tuples are written as provided.
 
 For an example that shows how to quickly index a 2M-documents corpus (Natural Questions), check out [`examples/index_nq.py`](examples/index_nq.py).
+
+### Acceleration Backends
+
+The default `backend="numpy"` path keeps scoring and top-k selection on CPU.
+`backend="numba"` enables the existing Numba retrieval path when Numba is
+installed. `backend="cupy"` enables GPU retrieval with CuPy and returns the
+same NumPy-shaped documents and scores as the CPU backend:
+
+```python
+retriever = bm25s.BM25(corpus=corpus, backend="cupy")
+retriever.index(corpus_tokens)
+documents, scores = retriever.retrieve(query_tokens, k=10)
+```
+
+You can also keep CPU scoring and use CuPy only for top-k selection:
+
+```python
+documents, scores = retriever.retrieve(
+    query_tokens,
+    k=10,
+    backend_selection="cupy",
+)
+```
+
+`backend="auto"` still chooses Numba when available and otherwise falls back to
+NumPy; it does not select CuPy automatically.
 
 ## High Level API
 

--- a/benchmarks/cupy_sparse_fastpath_benchmark.py
+++ b/benchmarks/cupy_sparse_fastpath_benchmark.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Synthetic throughput benchmark for the CuPy sparse BM25 fast path.
+
+This benchmark isolates BM25 retrieval only. It does not tokenize text and does
+not build an index; it generates a CSC score matrix directly so backend timing is
+not mixed with data preparation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+from bm25s.cupy.retrieve_utils import _retrieve_cupy_functional
+from bm25s.numba.retrieve_utils import _retrieve_numba_functional
+
+
+def now_utc_slug() -> str:
+    return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+
+
+def run_cmd(args: list[str], *, cwd: Path | None = None) -> str | None:
+    try:
+        return subprocess.check_output(
+            args, cwd=cwd, text=True, stderr=subprocess.DEVNULL
+        ).strip()
+    except Exception:
+        return None
+
+
+def make_scores(num_docs: int, vocab_size: int, postings_per_term: int, seed: int):
+    rng = np.random.default_rng(seed)
+    indices_parts = []
+    data_parts = []
+    indptr = np.empty(vocab_size + 1, dtype=np.int32)
+    cursor = 0
+    for term_id in range(vocab_size):
+        indptr[term_id] = cursor
+        docs = rng.choice(num_docs, size=postings_per_term, replace=False).astype(
+            np.int32
+        )
+        docs.sort()
+        values = rng.random(postings_per_term, dtype=np.float32) + np.float32(0.01)
+        indices_parts.append(docs)
+        data_parts.append(values)
+        cursor += postings_per_term
+    indptr[vocab_size] = cursor
+    return {
+        "data": np.concatenate(data_parts).astype(np.float32),
+        "indices": np.concatenate(indices_parts).astype(np.int32),
+        "indptr": indptr,
+        "num_docs": num_docs,
+    }
+
+
+def make_queries(num_queries: int, vocab_size: int, query_len: int, seed: int):
+    rng = np.random.default_rng(seed)
+    return [
+        rng.integers(0, vocab_size, size=query_len, dtype=np.int32)
+        for _ in range(num_queries)
+    ]
+
+
+def sync_gpu() -> None:
+    import cupy as cp
+
+    cp.cuda.Stream.null.synchronize()
+
+
+def gpu_snapshot() -> dict | None:
+    try:
+        import cupy as cp
+
+        free, total = cp.cuda.runtime.memGetInfo()
+        return {
+            "gpu_mem_free_mib": int(free // 1024 // 1024),
+            "gpu_mem_total_mib": int(total // 1024 // 1024),
+            "cupy_pool_used_mib": int(
+                cp.get_default_memory_pool().used_bytes() // 1024 // 1024
+            ),
+        }
+    except Exception:
+        return None
+
+
+def timed(name: str, fn, repeat: int, sync: bool):
+    samples = []
+    result = None
+    for _ in range(repeat):
+        t0 = time.perf_counter()
+        result = fn()
+        if sync:
+            sync_gpu()
+        samples.append(time.perf_counter() - t0)
+    best = min(samples)
+    return {
+        "name": name,
+        "elapsed_s_best": best,
+        "elapsed_s_samples": samples,
+        "result": result,
+    }
+
+
+def compare_docs(left: np.ndarray, right: np.ndarray) -> dict:
+    if left.shape != right.shape:
+        return {
+            "shape_mismatch": True,
+            "left_shape": list(left.shape),
+            "right_shape": list(right.shape),
+        }
+    overlaps = []
+    for left_row, right_row in zip(left, right):
+        left_set = set(int(x) for x in left_row)
+        right_set = set(int(x) for x in right_row)
+        overlaps.append(len(left_set & right_set) / max(len(left_set), 1))
+    diff = left != right
+    return {
+        "shape_mismatch": False,
+        "queries_with_different_order": int(diff.any(axis=1).sum()),
+        "different_positions": int(diff.sum()),
+        "mean_overlap_fraction": float(np.mean(overlaps)),
+        "min_overlap_fraction": float(np.min(overlaps)),
+    }
+
+
+def write_report(output_dir: Path, payload: dict) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "benchmark_results.json").write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False)
+    )
+
+    rows = payload["results"]
+    lines = [
+        "# CuPy Sparse Fast Path Benchmark",
+        "",
+        f"created_at_utc: `{payload['created_at_utc']}`",
+        f"bm25s_commit: `{payload['repo']['commit']}`",
+        f"num_docs: `{payload['workload']['num_docs']}`",
+        f"vocab_size: `{payload['workload']['vocab_size']}`",
+        f"postings_per_term: `{payload['workload']['postings_per_term']}`",
+        f"num_queries: `{payload['workload']['num_queries']}`",
+        f"query_len: `{payload['workload']['query_len']}`",
+        f"topk: `{payload['workload']['topk']}`",
+        "",
+        "| backend | best_s | qps | speedup_vs_numba | speedup_vs_cupy_dense |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for row in rows:
+        lines.append(
+            "| {name} | {elapsed:.6f} | {qps:.2f} | {numba:.3f}x | {dense:.3f}x |".format(
+                name=row["name"],
+                elapsed=row["elapsed_s_best"],
+                qps=row["queries_per_second"],
+                numba=row.get("speedup_vs_numba") or 0.0,
+                dense=row.get("speedup_vs_cupy_dense") or 0.0,
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Correctness",
+            "",
+            "```json",
+            json.dumps(payload["correctness"], indent=2),
+            "```",
+            "",
+        ]
+    )
+    (output_dir / "benchmark_summary.md").write_text("\n".join(lines))
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--output-dir", type=Path, default=Path("benchmarks/results") / f"cupy_sparse_fastpath_{now_utc_slug()}")
+    p.add_argument("--num-docs", type=int, default=200_000)
+    p.add_argument("--vocab-size", type=int, default=20_000)
+    p.add_argument("--postings-per-term", type=int, default=160)
+    p.add_argument("--num-queries", type=int, default=256)
+    p.add_argument("--query-len", type=int, default=16)
+    p.add_argument("--topk", type=int, default=100)
+    p.add_argument("--repeat", type=int, default=5)
+    p.add_argument("--seed", type=int, default=123)
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    scores = make_scores(
+        args.num_docs, args.vocab_size, args.postings_per_term, args.seed
+    )
+    queries = make_queries(
+        args.num_queries, args.vocab_size, args.query_len, args.seed + 1
+    )
+
+    def run_numba():
+        return _retrieve_numba_functional(
+            queries,
+            scores,
+            corpus=None,
+            k=args.topk,
+            sorted=True,
+            return_as="tuple",
+            show_progress=False,
+            n_threads=32,
+            backend_selection="numba",
+            dtype="float32",
+            int_dtype="int32",
+        )
+
+    def run_cupy_dense():
+        old = os.environ.get("BM25S_CUPY_SPARSE_MAX_POSTINGS")
+        os.environ["BM25S_CUPY_SPARSE_MAX_POSTINGS"] = "0"
+        try:
+            return _retrieve_cupy_functional(
+                queries,
+                scores,
+                corpus=None,
+                k=args.topk,
+                sorted=True,
+                return_as="tuple",
+                show_progress=False,
+                backend_selection="cupy",
+                dtype="float32",
+                int_dtype="int32",
+            )
+        finally:
+            if old is None:
+                os.environ.pop("BM25S_CUPY_SPARSE_MAX_POSTINGS", None)
+            else:
+                os.environ["BM25S_CUPY_SPARSE_MAX_POSTINGS"] = old
+
+    def run_cupy_sparse():
+        old = os.environ.get("BM25S_CUPY_SPARSE_MAX_POSTINGS")
+        os.environ["BM25S_CUPY_SPARSE_MAX_POSTINGS"] = str(10**12)
+        try:
+            return _retrieve_cupy_functional(
+                queries,
+                scores,
+                corpus=None,
+                k=args.topk,
+                sorted=True,
+                return_as="tuple",
+                show_progress=False,
+                backend_selection="cupy",
+                dtype="float32",
+                int_dtype="int32",
+            )
+        finally:
+            if old is None:
+                os.environ.pop("BM25S_CUPY_SPARSE_MAX_POSTINGS", None)
+            else:
+                os.environ["BM25S_CUPY_SPARSE_MAX_POSTINGS"] = old
+
+    # Warm compilation and GPU memory pools outside the timed samples.
+    numba_docs, numba_scores = run_numba()
+    dense_docs, dense_scores = run_cupy_dense()
+    sparse_docs, sparse_scores = run_cupy_sparse()
+    sync_gpu()
+
+    measurements = [
+        timed("numba", run_numba, args.repeat, sync=False),
+        timed("cupy_dense_fallback", run_cupy_dense, args.repeat, sync=True),
+        timed("cupy_sparse_fastpath", run_cupy_sparse, args.repeat, sync=True),
+    ]
+
+    base_numba = measurements[0]["elapsed_s_best"]
+    base_dense = measurements[1]["elapsed_s_best"]
+    results = []
+    for item in measurements:
+        elapsed = item["elapsed_s_best"]
+        row = {
+            "name": item["name"],
+            "elapsed_s_best": elapsed,
+            "elapsed_s_samples": item["elapsed_s_samples"],
+            "queries_per_second": args.num_queries / elapsed,
+            "speedup_vs_numba": base_numba / elapsed,
+            "speedup_vs_cupy_dense": base_dense / elapsed,
+        }
+        results.append(row)
+
+    payload = {
+        "created_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "command": " ".join(sys.argv),
+        "repo": {
+            "cwd": str(Path.cwd()),
+            "commit": run_cmd(["git", "rev-parse", "HEAD"], cwd=Path.cwd()),
+            "branch": run_cmd(["git", "branch", "--show-current"], cwd=Path.cwd()),
+            "status": run_cmd(["git", "status", "--short"], cwd=Path.cwd()),
+        },
+        "host": {
+            "hostname": platform.node(),
+            "platform": platform.platform(),
+            "python": sys.executable,
+            "cpu_count": os.cpu_count(),
+            "gpu": run_cmd(
+                [
+                    "nvidia-smi",
+                    "--query-gpu=name,memory.total,driver_version",
+                    "--format=csv,noheader",
+                ]
+            ),
+            "gpu_after": gpu_snapshot(),
+        },
+        "workload": {
+            "num_docs": args.num_docs,
+            "vocab_size": args.vocab_size,
+            "postings_per_term": args.postings_per_term,
+            "num_queries": args.num_queries,
+            "query_len": args.query_len,
+            "topk": args.topk,
+            "repeat": args.repeat,
+            "seed": args.seed,
+        },
+        "results": results,
+        "correctness": {
+            "numba_vs_cupy_dense_docs": compare_docs(numba_docs, dense_docs),
+            "numba_vs_cupy_sparse_docs": compare_docs(numba_docs, sparse_docs),
+            "cupy_dense_vs_sparse_docs": compare_docs(dense_docs, sparse_docs),
+            "numba_vs_cupy_dense_scores_max_abs_diff": float(
+                np.max(np.abs(numba_scores - dense_scores))
+            ),
+            "numba_vs_cupy_sparse_scores_max_abs_diff": float(
+                np.max(np.abs(numba_scores - sparse_scores))
+            ),
+            "cupy_dense_vs_sparse_scores_max_abs_diff": float(
+                np.max(np.abs(dense_scores - sparse_scores))
+            ),
+        },
+    }
+    write_report(args.output_dir, payload)
+    print(f"[bench] wrote {args.output_dir / 'benchmark_results.json'}", flush=True)
+    print(f"[bench] wrote {args.output_dir / 'benchmark_summary.md'}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bm25s/__init__.py
+++ b/bm25s/__init__.py
@@ -590,8 +590,11 @@ class BM25:
         For a given list of tokens, return the list of token IDs, leaving out tokens
         that are not in the vocabulary.
         """
+        vocab_get = self.vocab_dict.get
         return [
-            self.vocab_dict[token] for token in query_tokens if token in self.vocab_dict
+            token_id
+            for token in query_tokens
+            if (token_id := vocab_get(token)) is not None
         ]
 
     def get_scores_from_ids(

--- a/bm25s/__init__.py
+++ b/bm25s/__init__.py
@@ -19,6 +19,14 @@ try:
 except ImportError:
     njit = lambda x: x  # type: ignore
     NUMBA_AVAILABLE = False
+
+try:
+    from .cupy import selection as selection_cupy
+    CUPY_AVAILABLE = selection_cupy.CUPY_AVAILABLE
+except ImportError:
+    selection_cupy = None
+    CUPY_AVAILABLE = False
+
 try:
     import scipy.sparse as sp
     SCIPY_AVAILABLE = True
@@ -29,6 +37,11 @@ try:
     from .numba.retrieve_utils import _retrieve_numba_functional
 except ImportError:
     _retrieve_numba_functional = None
+
+try:
+    from .cupy.retrieve_utils import _retrieve_cupy_functional
+except ImportError:
+    _retrieve_cupy_functional = None
 
 
 def _faketqdm(*args, **kwargs):
@@ -193,9 +206,10 @@ class BM25:
         backend : str
             The backend used during retrieval. By default, it uses the numpy backend, which
             only requires numpy and scipy as dependencies. You can also select `backend="numba"`
-            to use the numba backend, which requires the numba library. If you select `backend="auto"`,
-            the function will use the numba backend if it is available, otherwise it will use the numpy
-            backend.
+            to use the numba backend, which requires the numba library, or `backend="cupy"`
+            to use the CuPy backend, which requires CuPy and a compatible CUDA runtime. If you
+            select `backend="auto"`, the function will use the numba backend if it is available,
+            otherwise it will use the numpy backend.
         
         csc_backend : str
             The backend used for constructing the CSC matrix. Choose from 'scipy' or 'numpy'. By default,
@@ -231,6 +245,11 @@ class BM25:
         if self.backend == "numba" and not NUMBA_AVAILABLE:
             raise ImportError(
                 "Numba is not installed. Please install numba with `pip install numba` to use the numba backend."
+            )
+
+        if self.backend == "cupy" and not CUPY_AVAILABLE:
+            raise ImportError(
+                "CuPy is not installed. Please install a CuPy package compatible with your CUDA runtime to use the cupy backend."
             )
         
         if csc_backend == "scipy" and not SCIPY_AVAILABLE:
@@ -663,6 +682,14 @@ class BM25:
             topk_scores, topk_indices = selection_jit.topk(
                 scores_q, k=k, sorted=sorted, backend=backend
             )
+        elif backend == "cupy":
+            if CUPY_AVAILABLE is False or selection_cupy is None:
+                raise ImportError(
+                    "CuPy is not installed. Please install a CuPy package compatible with your CUDA runtime to use this backend."
+                )
+            topk_scores, topk_indices = selection_cupy.topk(
+                scores_q, k=k, sorted=sorted, backend=backend
+            )
         else:
             topk_scores, topk_indices = selection_np.topk(
                 scores_q, k=k, sorted=sorted, backend=backend
@@ -840,6 +867,47 @@ class BM25:
                 raise ValueError(
                     "The length of the weight_mask must be the same as the length of the corpus."
                 )
+
+        if self.backend == "cupy":
+            if _retrieve_cupy_functional is None or not CUPY_AVAILABLE:
+                raise ImportError(
+                    "CuPy is not installed. Please install a CuPy package compatible with your CUDA runtime to use the cupy backend."
+                )
+
+            backend_selection = (
+                "cupy" if backend_selection == "auto" else backend_selection
+            )
+            if is_list_of_list_of_type(query_tokens, type_=int):
+                query_tokens_ids = query_tokens
+            elif is_list_of_list_of_type(query_tokens, type_=str):
+                query_tokens_ids = [self.get_tokens_ids(q) for q in query_tokens]
+            else:
+                raise ValueError(
+                    "The query_tokens must be a list of list of tokens (str for stemmed words, int for token ids matching corpus) or a tuple of two lists: the first list is the list of unique token IDs, and the second list is the list of token IDs for each document."
+                )
+
+            res = _retrieve_cupy_functional(
+                query_tokens_ids=query_tokens_ids,
+                scores=self.scores,
+                corpus=corpus,
+                k=k,
+                sorted=sorted,
+                return_as=return_as,
+                show_progress=show_progress,
+                leave_progress=leave_progress,
+                n_threads=n_threads,
+                chunksize=None,
+                backend_selection=backend_selection,
+                dtype=self.dtype,
+                int_dtype=self.int_dtype,
+                nonoccurrence_array=self.nonoccurrence_array,
+                weight_mask=weight_mask,
+            )
+
+            if return_as == "tuple":
+                return Results(documents=res[0], scores=res[1])
+            else:
+                return res
 
         if self.backend == "numba":
             if _retrieve_numba_functional is None:

--- a/bm25s/cupy/__init__.py
+++ b/bm25s/cupy/__init__.py
@@ -1,0 +1,5 @@
+"""CuPy backend helpers for BM25S."""
+
+from .selection import CUPY_AVAILABLE
+
+__all__ = ["CUPY_AVAILABLE"]

--- a/bm25s/cupy/retrieve_utils.py
+++ b/bm25s/cupy/retrieve_utils.py
@@ -1,0 +1,142 @@
+import logging
+from typing import Any, List
+
+import numpy as np
+
+from .. import utils
+from .selection import _require_cupy, topk
+
+
+def _score_query_cupy(
+    query_tokens_ids,
+    data,
+    indices,
+    indptr,
+    num_docs,
+    dtype,
+    nonoccurrence_array=None,
+    weight_mask=None,
+):
+    cupy = _require_cupy()
+    scores = cupy.zeros(num_docs, dtype=dtype)
+
+    for token_id in query_tokens_ids:
+        token_id = int(token_id)
+        start = int(indptr[token_id])
+        end = int(indptr[token_id + 1])
+        if end > start:
+            cupy.add.at(scores, indices[start:end], data[start:end])
+
+    if weight_mask is not None:
+        scores *= weight_mask
+
+    if nonoccurrence_array is not None and len(query_tokens_ids) > 0:
+        query_tokens_ids_gpu = cupy.asarray(query_tokens_ids, dtype=np.int64)
+        scores += nonoccurrence_array[query_tokens_ids_gpu].sum()
+
+    return scores
+
+
+def _retrieve_cupy_functional(
+    query_tokens_ids,
+    scores,
+    corpus: List[Any] = None,
+    k: int = 10,
+    sorted: bool = True,
+    return_as: str = "tuple",
+    show_progress: bool = True,
+    leave_progress: bool = False,
+    n_threads: int = 0,
+    chunksize: int = None,
+    nonoccurrence_array=None,
+    backend_selection="cupy",
+    dtype="float32",
+    int_dtype="int32",
+    weight_mask=None,
+):
+    cupy = _require_cupy()
+
+    if backend_selection == "auto":
+        backend_selection = "cupy"
+
+    if backend_selection != "cupy":
+        error_msg = (
+            "The `cupy` backend must use backend_selection='cupy' or 'auto'. "
+            "Please choose a different backend or change backend_selection to cupy."
+        )
+        raise ValueError(error_msg)
+
+    if chunksize is not None:
+        logging.warning(
+            "The `chunksize` parameter is ignored in the `retrieve` function "
+            "when using the `cupy` backend."
+        )
+
+    if n_threads not in (0, 1):
+        logging.warning(
+            "The `n_threads` parameter is ignored in the `retrieve` function "
+            "when using the `cupy` backend."
+        )
+
+    allowed_return_as = ["tuple", "documents"]
+    if return_as not in allowed_return_as:
+        raise ValueError("`return_as` must be either 'tuple' or 'documents'")
+
+    dtype = np.dtype(dtype)
+    int_dtype = np.dtype(int_dtype)
+    num_queries = len(query_tokens_ids)
+
+    data_gpu = cupy.asarray(scores["data"], dtype=dtype)
+    indices_gpu = cupy.asarray(scores["indices"], dtype=int_dtype)
+    indptr = np.asarray(scores["indptr"], dtype=int_dtype)
+
+    if nonoccurrence_array is not None:
+        nonoccurrence_array_gpu = cupy.asarray(nonoccurrence_array, dtype=dtype)
+    else:
+        nonoccurrence_array_gpu = None
+
+    if weight_mask is not None:
+        weight_mask_gpu = cupy.asarray(weight_mask)
+    else:
+        weight_mask_gpu = None
+
+    retrieved_scores = np.empty((num_queries, k), dtype=dtype)
+    retrieved_indices = np.empty((num_queries, k), dtype=int_dtype)
+
+    for i, query_tokens_ids_single in enumerate(query_tokens_ids):
+        query_tokens_ids_single = np.asarray(query_tokens_ids_single, dtype=int_dtype)
+        scores_single = _score_query_cupy(
+            query_tokens_ids=query_tokens_ids_single,
+            data=data_gpu,
+            indices=indices_gpu,
+            indptr=indptr,
+            num_docs=scores["num_docs"],
+            dtype=dtype,
+            nonoccurrence_array=nonoccurrence_array_gpu,
+            weight_mask=weight_mask_gpu,
+        )
+
+        topk_scores_sing, topk_indices_sing = topk(
+            scores_single, k=k, backend="cupy", sorted=sorted
+        )
+        retrieved_scores[i] = topk_scores_sing.astype(dtype, copy=False)
+        retrieved_indices[i] = topk_indices_sing.astype(int_dtype, copy=False)
+
+    if corpus is None:
+        retrieved_docs = retrieved_indices
+    else:
+        if isinstance(corpus, utils.corpus.JsonlCorpus):
+            retrieved_docs = corpus[retrieved_indices]
+        elif isinstance(corpus, np.ndarray) and corpus.ndim == 1:
+            retrieved_docs = corpus[retrieved_indices]
+        else:
+            index_flat = retrieved_indices.flatten().tolist()
+            results = [corpus[i] for i in index_flat]
+            retrieved_docs = np.array(results).reshape(retrieved_indices.shape)
+
+    if return_as == "tuple":
+        return retrieved_docs, retrieved_scores
+    elif return_as == "documents":
+        return retrieved_docs
+    else:
+        raise ValueError("`return_as` must be either 'tuple' or 'documents'")

--- a/bm25s/cupy/retrieve_utils.py
+++ b/bm25s/cupy/retrieve_utils.py
@@ -1,10 +1,1122 @@
 import logging
+import os
 from typing import Any, List
 
 import numpy as np
 
 from .. import utils
-from .selection import _require_cupy, topk
+from .selection import _require_cupy, _topk_cupy_gpu
+
+
+_CANDIDATE_SCORE_KERNEL = None
+_CANDIDATE_SCORE_COUNT_KERNEL = None
+_CANDIDATE_MARK_KERNEL = None
+_CANDIDATE_STAMP_KERNEL = None
+_CANDIDATE_DROPPED_SCORE_KERNEL = None
+_WARNED_IGNORED_CHUNKSIZE = False
+_WARNED_IGNORED_N_THREADS = False
+
+
+def _get_candidate_score_kernel():
+    global _CANDIDATE_SCORE_KERNEL
+    if _CANDIDATE_SCORE_KERNEL is not None:
+        return _CANDIDATE_SCORE_KERNEL
+
+    cupy = _require_cupy()
+    _CANDIDATE_SCORE_KERNEL = cupy.RawKernel(
+        r'''
+extern "C" __global__ void score_candidates_kernel(
+    const int* candidates,
+    const int n_candidates,
+    const int* query_terms,
+    const int q_len,
+    const float* data,
+    const int* indices,
+    const int* indptr,
+    float* out_scores) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i >= n_candidates) return;
+
+  int doc = candidates[i];
+  float score = 0.0f;
+  for (int t = 0; t < q_len; ++t) {
+    int term = query_terms[t];
+    int lo = indptr[term];
+    int hi = indptr[term + 1];
+    while (lo < hi) {
+      int mid = lo + ((hi - lo) >> 1);
+      int value = indices[mid];
+      if (value < doc) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    int end = indptr[term + 1];
+    if (lo < end && indices[lo] == doc) {
+      score += data[lo];
+    }
+  }
+  out_scores[i] = score;
+}
+''',
+        "score_candidates_kernel",
+    )
+    return _CANDIDATE_SCORE_KERNEL
+
+
+def _get_candidate_score_count_kernel():
+    global _CANDIDATE_SCORE_COUNT_KERNEL
+    if _CANDIDATE_SCORE_COUNT_KERNEL is not None:
+        return _CANDIDATE_SCORE_COUNT_KERNEL
+
+    cupy = _require_cupy()
+    _CANDIDATE_SCORE_COUNT_KERNEL = cupy.RawKernel(
+        r'''
+extern "C" __global__ void score_candidates_count_kernel(
+    const int* candidates,
+    const int total_slots,
+    const int* count,
+    const int* query_terms,
+    const int q_len,
+    const float* data,
+    const int* indices,
+    const int* indptr,
+    float* out_scores) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i >= total_slots) return;
+
+  int n_candidates = count[0];
+  if (i >= n_candidates) {
+    out_scores[i] = -3.402823466e+38F;
+    return;
+  }
+
+  int doc = candidates[i];
+  float score = 0.0f;
+  for (int t = 0; t < q_len; ++t) {
+    int term = query_terms[t];
+    int lo = indptr[term];
+    int hi = indptr[term + 1];
+    while (lo < hi) {
+      int mid = lo + ((hi - lo) >> 1);
+      int value = indices[mid];
+      if (value < doc) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    int end = indptr[term + 1];
+    if (lo < end && indices[lo] == doc) {
+      score += data[lo];
+    }
+  }
+  out_scores[i] = score;
+}
+''',
+        "score_candidates_count_kernel",
+    )
+    return _CANDIDATE_SCORE_COUNT_KERNEL
+
+
+def _get_candidate_mark_kernel():
+    global _CANDIDATE_MARK_KERNEL
+    if _CANDIDATE_MARK_KERNEL is not None:
+        return _CANDIDATE_MARK_KERNEL
+
+    cupy = _require_cupy()
+    _CANDIDATE_MARK_KERNEL = cupy.RawKernel(
+        r'''
+extern "C" __global__ void build_candidates_mark_kernel(
+    const int* term_starts,
+    const int* term_offsets,
+    const int n_terms,
+    const int total_postings,
+    const int* indices,
+    int* marks,
+    int* candidates,
+    int* count) {
+  int pos = blockDim.x * blockIdx.x + threadIdx.x;
+  if (pos >= total_postings) return;
+
+  int lo = 0;
+  int hi = n_terms;
+  while (lo < hi) {
+    int mid = lo + ((hi - lo) >> 1);
+    if (term_offsets[mid + 1] <= pos) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+
+  int term_idx = lo;
+  int src = term_starts[term_idx] + (pos - term_offsets[term_idx]);
+  int doc = indices[src];
+  if (atomicCAS(&marks[doc], 0, 1) == 0) {
+    int out = atomicAdd(count, 1);
+    candidates[out] = doc;
+  }
+}
+''',
+        "build_candidates_mark_kernel",
+    )
+    return _CANDIDATE_MARK_KERNEL
+
+
+def _get_candidate_stamp_kernel():
+    global _CANDIDATE_STAMP_KERNEL
+    if _CANDIDATE_STAMP_KERNEL is not None:
+        return _CANDIDATE_STAMP_KERNEL
+
+    cupy = _require_cupy()
+    _CANDIDATE_STAMP_KERNEL = cupy.RawKernel(
+        r'''
+extern "C" __global__ void build_candidates_stamp_kernel(
+    const int* term_starts,
+    const int* term_offsets,
+    const int n_terms,
+    const int total_postings,
+    const int* indices,
+    int* marks,
+    const int stamp,
+    int* candidates,
+    int* count) {
+  int pos = blockDim.x * blockIdx.x + threadIdx.x;
+  if (pos >= total_postings) return;
+
+  int lo = 0;
+  int hi = n_terms;
+  while (lo < hi) {
+    int mid = lo + ((hi - lo) >> 1);
+    if (term_offsets[mid + 1] <= pos) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+
+  int term_idx = lo;
+  int src = term_starts[term_idx] + (pos - term_offsets[term_idx]);
+  int doc = indices[src];
+  int old = atomicExch(&marks[doc], stamp);
+  if (old != stamp) {
+    int out = atomicAdd(count, 1);
+    candidates[out] = doc;
+  }
+}
+''',
+        "build_candidates_stamp_kernel",
+    )
+    return _CANDIDATE_STAMP_KERNEL
+
+
+def _get_candidate_dropped_score_kernel():
+    global _CANDIDATE_DROPPED_SCORE_KERNEL
+    if _CANDIDATE_DROPPED_SCORE_KERNEL is not None:
+        return _CANDIDATE_DROPPED_SCORE_KERNEL
+
+    cupy = _require_cupy()
+    _CANDIDATE_DROPPED_SCORE_KERNEL = cupy.RawKernel(
+        r'''
+extern "C" __global__ void add_dropped_scores_kernel(
+    const int* candidate_docs,
+    const int nnz,
+    const int* row_ids,
+    const int* drop_terms,
+    const int* drop_offsets,
+    const float* data,
+    const int* indices,
+    const int* indptr,
+    float* candidate_scores) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i >= nnz) return;
+
+  int row = row_ids[i];
+  int doc = candidate_docs[i];
+  float score = candidate_scores[i];
+  for (int p = drop_offsets[row]; p < drop_offsets[row + 1]; ++p) {
+    int term = drop_terms[p];
+    int lo = indptr[term];
+    int hi = indptr[term + 1];
+    while (lo < hi) {
+      int mid = lo + ((hi - lo) >> 1);
+      int value = indices[mid];
+      if (value < doc) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    int end = indptr[term + 1];
+    if (lo < end && indices[lo] == doc) {
+      score += data[lo];
+    }
+  }
+  candidate_scores[i] = score;
+}
+''',
+        "add_dropped_scores_kernel",
+    )
+    return _CANDIDATE_DROPPED_SCORE_KERNEL
+
+
+def _get_cupy_index_cache(scores, dtype, int_dtype):
+    cupy = _require_cupy()
+    cache = scores.get("_cupy_cache")
+    cache_key = (str(np.dtype(dtype)), str(np.dtype(int_dtype)))
+    if cache is not None and cache.get("key") == cache_key:
+        return cache
+
+    indptr_cpu = np.asarray(scores["indptr"], dtype=int_dtype)
+    cache = {
+        "key": cache_key,
+        "data": cupy.asarray(scores["data"], dtype=dtype),
+        "indices": cupy.asarray(scores["indices"], dtype=int_dtype),
+        "indptr_gpu": cupy.asarray(indptr_cpu, dtype=int_dtype),
+        "indptr_cpu": indptr_cpu,
+    }
+    scores["_cupy_cache"] = cache
+    return cache
+
+
+def _get_term_max_cache(scores, dtype):
+    cache = scores.get("_term_max_cache")
+    cache_key = str(np.dtype(dtype))
+    if cache is not None and cache.get("key") == cache_key:
+        return cache["term_max"]
+
+    data = np.asarray(scores["data"], dtype=dtype)
+    indptr = np.asarray(scores["indptr"])
+    term_max = np.zeros(len(indptr) - 1, dtype=dtype)
+    for term_id in range(len(term_max)):
+        start = int(indptr[term_id])
+        end = int(indptr[term_id + 1])
+        if end > start:
+            term_max[term_id] = data[start:end].max()
+    scores["_term_max_cache"] = {"key": cache_key, "term_max": term_max}
+    return term_max
+
+
+def _get_cupy_spmm_cache(scores, dtype, int_dtype):
+    cache = scores.get("_cupy_spmm_cache")
+    cache_key = (str(np.dtype(dtype)), str(np.dtype(int_dtype)))
+    if cache is not None and cache.get("key") == cache_key:
+        return cache
+
+    cupy = _require_cupy()
+    import cupyx.scipy.sparse as cupy_sparse
+
+    index_cache = _get_cupy_index_cache(scores, dtype=dtype, int_dtype=int_dtype)
+    num_docs = int(scores["num_docs"])
+    n_terms = len(index_cache["indptr_cpu"]) - 1
+    score_matrix = cupy_sparse.csc_matrix(
+        (
+            index_cache["data"],
+            index_cache["indices"],
+            index_cache["indptr_gpu"],
+        ),
+        shape=(num_docs, n_terms),
+    )
+    cache = {
+        "key": cache_key,
+        "score_matrix_t": score_matrix.T.tocsr(),
+        "n_terms": n_terms,
+        "empty_int": cupy.empty(0, dtype=int_dtype),
+        "empty_float": cupy.empty(0, dtype=dtype),
+    }
+    scores["_cupy_spmm_cache"] = cache
+    return cache
+
+
+def _unique_sorted_cupy(values):
+    cupy = _require_cupy()
+
+    values = cupy.sort(values)
+    if values.size == 0:
+        return values
+
+    keep = cupy.empty(values.shape, dtype=cupy.bool_)
+    keep[0] = True
+    keep[1:] = values[1:] != values[:-1]
+    return values[keep]
+
+
+def _candidate_terms_from_query(query_terms, indptr_cpu, df_threshold: int):
+    dfs = indptr_cpu[query_terms + 1] - indptr_cpu[query_terms]
+    kept_terms = query_terms[dfs <= df_threshold]
+    dropped_terms = query_terms[dfs > df_threshold]
+    return np.unique(kept_terms), dropped_terms
+
+
+def _resolve_candidate_certification(
+    candidate_positions,
+    topk_scores,
+    outside_bounds,
+):
+    if not candidate_positions:
+        return []
+
+    cupy = _require_cupy()
+    kth_scores = cupy.asnumpy(cupy.stack([scores[-1] for scores in topk_scores]))
+    return [
+        query_pos
+        for query_pos, kth_score, outside_bound in zip(
+            candidate_positions, kth_scores, outside_bounds
+        )
+        if kth_score <= outside_bound
+    ]
+
+
+def _build_candidates_sort_cupy(candidate_terms, indptr_cpu, indices_gpu):
+    cupy = _require_cupy()
+    candidate_parts = [
+        indices_gpu[int(indptr_cpu[term_id]) : int(indptr_cpu[term_id + 1])]
+        for term_id in candidate_terms
+    ]
+    return _unique_sorted_cupy(cupy.concatenate(candidate_parts))
+
+
+def _build_candidates_atomic_cupy(
+    candidate_terms,
+    indptr_cpu,
+    indices_gpu,
+    marks_gpu,
+    count_gpu,
+):
+    cupy = _require_cupy()
+    starts = indptr_cpu[candidate_terms].astype(np.int32, copy=False)
+    ends = indptr_cpu[candidate_terms + 1].astype(np.int32, copy=False)
+    posting_lengths = (ends - starts).astype(np.int32, copy=False)
+    total_postings = int(posting_lengths.sum())
+    if total_postings == 0:
+        return cupy.empty(0, dtype=indices_gpu.dtype)
+
+    if total_postings > np.iinfo(np.int32).max:
+        return _build_candidates_sort_cupy(candidate_terms, indptr_cpu, indices_gpu)
+
+    offsets = np.empty(len(posting_lengths) + 1, dtype=np.int32)
+    offsets[0] = 0
+    np.cumsum(posting_lengths, dtype=np.int32, out=offsets[1:])
+
+    candidates = cupy.empty(total_postings, dtype=indices_gpu.dtype)
+    count_gpu.fill(0)
+    block_size = 256
+    grid_size = (total_postings + block_size - 1) // block_size
+    _get_candidate_mark_kernel()(
+        (grid_size,),
+        (block_size,),
+        (
+            cupy.asarray(starts),
+            cupy.asarray(offsets),
+            np.int32(len(posting_lengths)),
+            np.int32(total_postings),
+            indices_gpu,
+            marks_gpu,
+            candidates,
+            count_gpu,
+        ),
+    )
+    n_candidates = int(count_gpu.get()[0])
+    candidates = candidates[:n_candidates]
+    if n_candidates:
+        marks_gpu[candidates] = 0
+    return candidates
+
+
+def _build_candidates_stamp_cupy(
+    candidate_terms,
+    indptr_cpu,
+    indices_gpu,
+    marks_gpu,
+    count_gpu,
+    stamp: int,
+):
+    cupy = _require_cupy()
+    starts = indptr_cpu[candidate_terms].astype(np.int32, copy=False)
+    ends = indptr_cpu[candidate_terms + 1].astype(np.int32, copy=False)
+    posting_lengths = (ends - starts).astype(np.int32, copy=False)
+    total_postings = int(posting_lengths.sum())
+    if total_postings == 0:
+        return cupy.empty(0, dtype=indices_gpu.dtype)
+
+    if total_postings > np.iinfo(np.int32).max:
+        return _build_candidates_sort_cupy(candidate_terms, indptr_cpu, indices_gpu)
+
+    offsets = np.empty(len(posting_lengths) + 1, dtype=np.int32)
+    offsets[0] = 0
+    np.cumsum(posting_lengths, dtype=np.int32, out=offsets[1:])
+
+    candidates = cupy.empty(total_postings, dtype=indices_gpu.dtype)
+    count_gpu.fill(0)
+    block_size = 256
+    grid_size = (total_postings + block_size - 1) // block_size
+    _get_candidate_stamp_kernel()(
+        (grid_size,),
+        (block_size,),
+        (
+            cupy.asarray(starts),
+            cupy.asarray(offsets),
+            np.int32(len(posting_lengths)),
+            np.int32(total_postings),
+            indices_gpu,
+            marks_gpu,
+            np.int32(stamp),
+            candidates,
+            count_gpu,
+        ),
+    )
+    n_candidates = int(count_gpu.get()[0])
+    return candidates[:n_candidates]
+
+
+def _build_candidates_stamp_slots_cupy(
+    candidate_terms,
+    indptr_cpu,
+    indices_gpu,
+    marks_gpu,
+    count_gpu,
+    stamp: int,
+):
+    cupy = _require_cupy()
+    starts = indptr_cpu[candidate_terms].astype(np.int32, copy=False)
+    ends = indptr_cpu[candidate_terms + 1].astype(np.int32, copy=False)
+    posting_lengths = (ends - starts).astype(np.int32, copy=False)
+    total_postings = int(posting_lengths.sum())
+    if total_postings == 0:
+        return cupy.empty(0, dtype=indices_gpu.dtype), 0, count_gpu
+
+    if total_postings > np.iinfo(np.int32).max:
+        candidates = _build_candidates_sort_cupy(candidate_terms, indptr_cpu, indices_gpu)
+        count_gpu[0] = candidates.size
+        return candidates, int(candidates.size), count_gpu
+
+    offsets = np.empty(len(posting_lengths) + 1, dtype=np.int32)
+    offsets[0] = 0
+    np.cumsum(posting_lengths, dtype=np.int32, out=offsets[1:])
+
+    candidates = cupy.empty(total_postings, dtype=indices_gpu.dtype)
+    count_gpu.fill(0)
+    block_size = 256
+    grid_size = (total_postings + block_size - 1) // block_size
+    _get_candidate_stamp_kernel()(
+        (grid_size,),
+        (block_size,),
+        (
+            cupy.asarray(starts),
+            cupy.asarray(offsets),
+            np.int32(len(posting_lengths)),
+            np.int32(total_postings),
+            indices_gpu,
+            marks_gpu,
+            np.int32(stamp),
+            candidates,
+            count_gpu,
+        ),
+    )
+    return candidates, total_postings, count_gpu
+
+
+def _build_query_low_df_csr_cupy(
+    query_batch,
+    indptr_cpu,
+    df_threshold,
+    n_terms,
+    dtype,
+    int_dtype,
+):
+    cupy = _require_cupy()
+    import cupyx.scipy.sparse as cupy_sparse
+
+    q_indptr = [0]
+    q_indices = []
+    q_data = []
+    drop_offsets = [0]
+    drop_terms = []
+    for query_terms in query_batch:
+        query_terms = np.asarray(query_terms, dtype=int_dtype)
+        if query_terms.size:
+            dfs = indptr_cpu[query_terms + 1] - indptr_cpu[query_terms]
+            low_terms = query_terms[dfs <= df_threshold]
+            dropped = query_terms[dfs > df_threshold]
+            if low_terms.size:
+                q_indices.extend(low_terms.tolist())
+                q_data.extend([1.0] * int(low_terms.size))
+            drop_terms.extend(dropped.tolist())
+        q_indptr.append(len(q_indices))
+        drop_offsets.append(len(drop_terms))
+
+    query_matrix = cupy_sparse.csr_matrix(
+        (
+            cupy.asarray(q_data, dtype=dtype),
+            cupy.asarray(q_indices, dtype=int_dtype),
+            cupy.asarray(q_indptr, dtype=int_dtype),
+        ),
+        shape=(len(query_batch), n_terms),
+    )
+    return (
+        query_matrix,
+        cupy.asarray(drop_terms, dtype=int_dtype),
+        cupy.asarray(drop_offsets, dtype=int_dtype),
+    )
+
+
+def _add_dropped_scores_to_csr_cupy(
+    candidates_csr,
+    drop_terms,
+    drop_offsets,
+    scores_cache,
+):
+    cupy = _require_cupy()
+    nnz = int(candidates_csr.nnz)
+    if nnz == 0 or int(drop_terms.size) == 0:
+        return
+
+    row_counts = candidates_csr.indptr[1:] - candidates_csr.indptr[:-1]
+    row_ids = cupy.repeat(cupy.arange(candidates_csr.shape[0], dtype=cupy.int32), row_counts)
+    block_size = 256
+    grid_size = (nnz + block_size - 1) // block_size
+    _get_candidate_dropped_score_kernel()(
+        (grid_size,),
+        (block_size,),
+        (
+            candidates_csr.indices,
+            np.int32(nnz),
+            row_ids,
+            drop_terms,
+            drop_offsets,
+            scores_cache["data"],
+            scores_cache["indices"],
+            scores_cache["indptr_gpu"],
+            candidates_csr.data,
+        ),
+    )
+
+
+def _topk_from_csr_rows_cupy(candidates_csr, k, dtype, int_dtype, indptr_cpu=None):
+    cupy = _require_cupy()
+    docs_rows = []
+    score_rows = []
+    fallback_rows = []
+    if indptr_cpu is None:
+        indptr_cpu = cupy.asnumpy(candidates_csr.indptr)
+    for row in range(candidates_csr.shape[0]):
+        start = int(indptr_cpu[row])
+        end = int(indptr_cpu[row + 1])
+        row_scores = candidates_csr.data[start:end]
+        if int(row_scores.size) < k:
+            fallback_rows.append(row)
+            docs_rows.append(None)
+            score_rows.append(None)
+            continue
+        row_docs = candidates_csr.indices[start:end]
+        order = cupy.argsort(row_scores)[-k:][::-1]
+        docs_rows.append(row_docs[order].astype(int_dtype, copy=False))
+        score_rows.append(row_scores[order].astype(dtype, copy=False))
+    return docs_rows, score_rows, fallback_rows
+
+
+def _retrieve_sparse_batch_cupy(
+    query_tokens_ids,
+    scores,
+    k: int,
+    dtype,
+    int_dtype,
+    max_postings: int = 50_000_000,
+):
+    """Retrieve a sparse batch exactly when all rows have at least k non-zero docs.
+
+    BM25 score entries are non-negative for the methods that use this fast path.
+    Therefore, if a query has at least k scored documents, its dense top-k is
+    contained in the non-zero candidate set and we can avoid scanning all docs.
+    """
+    cupy = _require_cupy()
+    dtype = np.dtype(dtype)
+    int_dtype = np.dtype(int_dtype)
+    num_queries = len(query_tokens_ids)
+    num_docs = int(scores["num_docs"])
+    if num_queries == 0 or k == 0:
+        return (
+            np.empty((num_queries, k), dtype=int_dtype),
+            np.empty((num_queries, k), dtype=dtype),
+        )
+
+    query_lengths = np.asarray([len(q) for q in query_tokens_ids], dtype=np.int64)
+    if np.any(query_lengths == 0):
+        return None
+
+    cache = _get_cupy_index_cache(scores, dtype=dtype, int_dtype=int_dtype)
+    data_gpu = cache["data"]
+    indices_gpu = cache["indices"]
+    indptr_cpu = cache["indptr_cpu"]
+
+    term_ids = np.concatenate(
+        [np.asarray(q, dtype=int_dtype) for q in query_tokens_ids]
+    )
+    starts = indptr_cpu[term_ids].astype(np.int64, copy=False)
+    ends = indptr_cpu[term_ids + 1].astype(np.int64, copy=False)
+    posting_lengths = ends - starts
+    total_postings = int(posting_lengths.sum())
+    if total_postings == 0 or total_postings > max_postings:
+        return None
+
+    offsets = np.empty(len(posting_lengths) + 1, dtype=np.int64)
+    offsets[0] = 0
+    np.cumsum(posting_lengths, dtype=np.int64, out=offsets[1:])
+    term_rows = np.repeat(np.arange(num_queries, dtype=np.int32), query_lengths)
+
+    offsets_gpu = cupy.asarray(offsets)
+    starts_gpu = cupy.asarray(starts)
+    rows_gpu = cupy.asarray(term_rows)
+
+    pos = cupy.arange(total_postings, dtype=cupy.int64)
+    term_ix = cupy.searchsorted(offsets_gpu[1:], pos, side="right")
+    src = starts_gpu[term_ix] + (pos - offsets_gpu[term_ix])
+    rows = rows_gpu[term_ix].astype(cupy.int64)
+    docs = indices_gpu[src].astype(cupy.int64)
+    vals = data_gpu[src]
+
+    keys = rows * num_docs + docs
+    order = cupy.argsort(keys)
+    keys = keys[order]
+    vals = vals[order]
+
+    is_new = cupy.empty(keys.shape, dtype=cupy.bool_)
+    is_new[0] = True
+    is_new[1:] = keys[1:] != keys[:-1]
+    group = cupy.cumsum(is_new, dtype=cupy.int64) - 1
+    n_groups = int(group[-1].get()) + 1
+
+    summed_scores = cupy.zeros(n_groups, dtype=dtype)
+    cupy.add.at(summed_scores, group, vals)
+    unique_keys = keys[is_new]
+    unique_rows = (unique_keys // num_docs).astype(cupy.int32)
+    unique_docs = (unique_keys - unique_rows.astype(cupy.int64) * num_docs).astype(
+        cupy.int32
+    )
+
+    counts = cupy.bincount(unique_rows, minlength=num_queries)
+    if bool(cupy.any(counts < k).get()):
+        return None
+
+    lex_keys = cupy.stack(
+        (
+            unique_docs.astype(cupy.float64),
+            (-summed_scores).astype(cupy.float64),
+            unique_rows.astype(cupy.float64),
+        )
+    )
+    order = cupy.lexsort(lex_keys)
+    rows_sorted = unique_rows[order]
+    docs_sorted = unique_docs[order]
+    scores_sorted = summed_scores[order]
+
+    sorted_counts = cupy.bincount(rows_sorted, minlength=num_queries)
+    row_starts = cupy.cumsum(
+        cupy.concatenate(
+            [cupy.asarray([0], dtype=sorted_counts.dtype), sorted_counts[:-1]]
+        )
+    )
+    ranks = cupy.arange(rows_sorted.size, dtype=cupy.int64) - cupy.repeat(
+        row_starts, sorted_counts
+    ).astype(cupy.int64)
+    keep = ranks < k
+
+    retrieved_indices = cupy.empty((num_queries, k), dtype=int_dtype)
+    retrieved_scores = cupy.empty((num_queries, k), dtype=dtype)
+    flat_positions = rows_sorted[keep].astype(cupy.int64) * k + ranks[keep]
+    retrieved_indices.ravel()[flat_positions] = docs_sorted[keep].astype(int_dtype)
+    retrieved_scores.ravel()[flat_positions] = scores_sorted[keep].astype(dtype)
+
+    return cupy.asnumpy(retrieved_indices), cupy.asnumpy(retrieved_scores)
+
+
+def _retrieve_spmm_batch_cupy(
+    query_tokens_ids,
+    scores,
+    k: int,
+    dtype,
+    int_dtype,
+    df_threshold: int,
+    batch_size: int = 160,
+):
+    cupy = _require_cupy()
+    dtype = np.dtype(dtype)
+    int_dtype = np.dtype(int_dtype)
+    if dtype != np.dtype("float32") or int_dtype != np.dtype("int32"):
+        return None
+
+    num_queries = len(query_tokens_ids)
+    if num_queries == 0:
+        return (
+            np.empty((0, k), dtype=int_dtype),
+            np.empty((0, k), dtype=dtype),
+        )
+
+    index_cache = _get_cupy_index_cache(scores, dtype=dtype, int_dtype=int_dtype)
+    spmm_cache = _get_cupy_spmm_cache(scores, dtype=dtype, int_dtype=int_dtype)
+    indptr_cpu = index_cache["indptr_cpu"]
+    term_max = _get_term_max_cache(scores, dtype=dtype)
+
+    retrieved_docs = [None] * num_queries
+    retrieved_scores = [None] * num_queries
+    fallback_positions = []
+    cert_candidate_positions = []
+    cert_topk_scores = []
+    cert_outside_bounds = []
+
+    batch_size = max(int(batch_size), 1)
+    for start in range(0, num_queries, batch_size):
+        end = min(start + batch_size, num_queries)
+        query_batch = [
+            np.asarray(query_tokens_ids[pos], dtype=int_dtype)
+            for pos in range(start, end)
+        ]
+        if any(len(query_terms) == 0 for query_terms in query_batch):
+            for local_pos, query_terms in enumerate(query_batch):
+                if len(query_terms) == 0:
+                    fallback_positions.append(start + local_pos)
+
+        query_matrix, drop_terms_gpu, drop_offsets_gpu = _build_query_low_df_csr_cupy(
+            query_batch,
+            indptr_cpu=indptr_cpu,
+            df_threshold=df_threshold,
+            n_terms=spmm_cache["n_terms"],
+            dtype=dtype,
+            int_dtype=int_dtype,
+        )
+        if int(query_matrix.nnz) == 0:
+            fallback_positions.extend(range(start, end))
+            continue
+
+        candidate_scores_csr = query_matrix @ spmm_cache["score_matrix_t"]
+        _add_dropped_scores_to_csr_cupy(
+            candidate_scores_csr,
+            drop_terms=drop_terms_gpu,
+            drop_offsets=drop_offsets_gpu,
+            scores_cache=index_cache,
+        )
+        candidate_indptr_cpu = cupy.asnumpy(candidate_scores_csr.indptr)
+        docs_rows, score_rows, local_fallback_rows = _topk_from_csr_rows_cupy(
+            candidate_scores_csr,
+            k=k,
+            dtype=dtype,
+            int_dtype=int_dtype,
+            indptr_cpu=candidate_indptr_cpu,
+        )
+        fallback_positions.extend(start + row for row in local_fallback_rows)
+
+        for local_pos, (docs_row, scores_row) in enumerate(zip(docs_rows, score_rows)):
+            query_pos = start + local_pos
+            if docs_row is None:
+                continue
+            query_terms = query_batch[local_pos]
+            dfs = indptr_cpu[query_terms + 1] - indptr_cpu[query_terms]
+            dropped_terms = query_terms[dfs > df_threshold]
+            outside_bound = (
+                float(term_max[dropped_terms].sum()) if len(dropped_terms) else 0.0
+            )
+            retrieved_docs[query_pos] = docs_row
+            retrieved_scores[query_pos] = scores_row
+            cert_candidate_positions.append(query_pos)
+            cert_topk_scores.append(scores_row)
+            cert_outside_bounds.append(outside_bound)
+
+    fallback_positions.extend(
+        _resolve_candidate_certification(
+            candidate_positions=cert_candidate_positions,
+            topk_scores=cert_topk_scores,
+            outside_bounds=cert_outside_bounds,
+        )
+    )
+    fallback_positions = sorted(set(fallback_positions))
+    for query_pos in fallback_positions:
+        retrieved_docs[query_pos] = None
+        retrieved_scores[query_pos] = None
+
+    if fallback_positions:
+        fallback_docs, fallback_scores = _retrieve_dense_batch_cupy(
+            [query_tokens_ids[pos] for pos in fallback_positions],
+            scores,
+            k=k,
+            sorted=True,
+            dtype=dtype,
+            int_dtype=int_dtype,
+        )
+        for fallback_idx, query_pos in enumerate(fallback_positions):
+            retrieved_docs[query_pos] = cupy.asarray(
+                fallback_docs[fallback_idx], dtype=int_dtype
+            )
+            retrieved_scores[query_pos] = cupy.asarray(
+                fallback_scores[fallback_idx], dtype=dtype
+            )
+
+    return (
+        cupy.asnumpy(cupy.stack(retrieved_docs)),
+        cupy.asnumpy(cupy.stack(retrieved_scores)),
+    )
+
+
+def _retrieve_dense_batch_cupy(
+    query_tokens_ids,
+    scores,
+    k: int,
+    sorted: bool,
+    dtype,
+    int_dtype,
+    nonoccurrence_array=None,
+    weight_mask=None,
+):
+    cupy = _require_cupy()
+    dtype = np.dtype(dtype)
+    int_dtype = np.dtype(int_dtype)
+    num_queries = len(query_tokens_ids)
+    if num_queries == 0:
+        return (
+            np.empty((0, k), dtype=int_dtype),
+            np.empty((0, k), dtype=dtype),
+        )
+
+    cache = _get_cupy_index_cache(scores, dtype=dtype, int_dtype=int_dtype)
+    data_gpu = cache["data"]
+    indices_gpu = cache["indices"]
+    indptr = cache["indptr_cpu"]
+
+    if nonoccurrence_array is not None:
+        nonoccurrence_array_gpu = cupy.asarray(nonoccurrence_array, dtype=dtype)
+    else:
+        nonoccurrence_array_gpu = None
+
+    if weight_mask is not None:
+        weight_mask_gpu = cupy.asarray(weight_mask)
+    else:
+        weight_mask_gpu = None
+
+    retrieved_scores_gpu = []
+    retrieved_indices_gpu = []
+    for query_tokens_ids_single in query_tokens_ids:
+        query_tokens_ids_single = np.asarray(query_tokens_ids_single, dtype=int_dtype)
+        scores_single = _score_query_cupy(
+            query_tokens_ids=query_tokens_ids_single,
+            data=data_gpu,
+            indices=indices_gpu,
+            indptr=indptr,
+            num_docs=scores["num_docs"],
+            dtype=dtype,
+            nonoccurrence_array=nonoccurrence_array_gpu,
+            weight_mask=weight_mask_gpu,
+        )
+
+        topk_scores_sing, topk_indices_sing = _topk_cupy_gpu(
+            scores_single, k=k, sorted=sorted
+        )
+        retrieved_scores_gpu.append(topk_scores_sing.astype(dtype, copy=False))
+        retrieved_indices_gpu.append(topk_indices_sing.astype(int_dtype, copy=False))
+
+    return (
+        cupy.asnumpy(cupy.stack(retrieved_indices_gpu)),
+        cupy.asnumpy(cupy.stack(retrieved_scores_gpu)),
+    )
+
+
+def _retrieve_candidate_batch_cupy(
+    query_tokens_ids,
+    scores,
+    k: int,
+    dtype,
+    int_dtype,
+    df_threshold: int,
+):
+    cupy = _require_cupy()
+    dtype = np.dtype(dtype)
+    int_dtype = np.dtype(int_dtype)
+    if dtype != np.dtype("float32") or int_dtype != np.dtype("int32"):
+        return None
+
+    num_queries = len(query_tokens_ids)
+    if num_queries == 0:
+        return (
+            np.empty((0, k), dtype=int_dtype),
+            np.empty((0, k), dtype=dtype),
+        )
+
+    union_mode = os.environ.get("BM25S_CUPY_CANDIDATE_UNION", "spmm")
+    if union_mode == "spmm":
+        return _retrieve_spmm_batch_cupy(
+            query_tokens_ids=query_tokens_ids,
+            scores=scores,
+            k=k,
+            dtype=dtype,
+            int_dtype=int_dtype,
+            df_threshold=df_threshold,
+            batch_size=int(os.environ.get("BM25S_CUPY_SPMM_BATCH_SIZE", "256")),
+        )
+
+    cache = _get_cupy_index_cache(scores, dtype=dtype, int_dtype=int_dtype)
+    data_gpu = cache["data"]
+    indices_gpu = cache["indices"]
+    indptr_gpu = cache["indptr_gpu"]
+    indptr_cpu = cache["indptr_cpu"]
+    term_max = _get_term_max_cache(scores, dtype=dtype)
+    kernel = _get_candidate_score_kernel()
+    count_kernel = _get_candidate_score_count_kernel()
+    if union_mode in {"atomic", "stamp", "stamp_slots"}:
+        candidate_marks_gpu = cupy.zeros(int(scores["num_docs"]), dtype=cupy.int32)
+        candidate_count_gpu = cupy.zeros(1, dtype=cupy.int32)
+    else:
+        candidate_marks_gpu = None
+        candidate_count_gpu = None
+
+    retrieved_docs = [None] * num_queries
+    retrieved_scores = [None] * num_queries
+    fallback_positions = []
+    cert_candidate_positions = []
+    cert_topk_scores = []
+    cert_outside_bounds = []
+
+    for query_pos, query_tokens_ids_single in enumerate(query_tokens_ids):
+        query_tokens_ids_single = np.asarray(query_tokens_ids_single, dtype=int_dtype)
+        if len(query_tokens_ids_single) == 0:
+            fallback_positions.append(query_pos)
+            continue
+
+        candidate_terms, dropped_terms = _candidate_terms_from_query(
+            query_terms=query_tokens_ids_single,
+            indptr_cpu=indptr_cpu,
+            df_threshold=df_threshold,
+        )
+        if len(candidate_terms) == 0:
+            fallback_positions.append(query_pos)
+            continue
+
+        if union_mode == "stamp_slots":
+            candidates, n_score_slots, count_gpu = _build_candidates_stamp_slots_cupy(
+                candidate_terms=candidate_terms,
+                indptr_cpu=indptr_cpu,
+                indices_gpu=indices_gpu,
+                marks_gpu=candidate_marks_gpu,
+                count_gpu=candidate_count_gpu,
+                stamp=query_pos + 1,
+            )
+            n_candidates = n_score_slots
+        elif union_mode == "stamp":
+            candidates = _build_candidates_stamp_cupy(
+                candidate_terms=candidate_terms,
+                indptr_cpu=indptr_cpu,
+                indices_gpu=indices_gpu,
+                marks_gpu=candidate_marks_gpu,
+                count_gpu=candidate_count_gpu,
+                stamp=query_pos + 1,
+            )
+            n_score_slots = int(candidates.size)
+            count_gpu = None
+        elif union_mode == "atomic":
+            candidates = _build_candidates_atomic_cupy(
+                candidate_terms=candidate_terms,
+                indptr_cpu=indptr_cpu,
+                indices_gpu=indices_gpu,
+                marks_gpu=candidate_marks_gpu,
+                count_gpu=candidate_count_gpu,
+            )
+            n_score_slots = int(candidates.size)
+            count_gpu = None
+        else:
+            candidates = _build_candidates_sort_cupy(
+                candidate_terms=candidate_terms,
+                indptr_cpu=indptr_cpu,
+                indices_gpu=indices_gpu,
+            )
+            n_score_slots = int(candidates.size)
+            count_gpu = None
+
+        n_candidates = int(candidates.size)
+        if n_candidates < k:
+            fallback_positions.append(query_pos)
+            continue
+
+        block_size = 256
+        grid_size = (n_score_slots + block_size - 1) // block_size
+        candidate_scores = cupy.empty(n_score_slots, dtype=dtype)
+        query_terms_gpu = cupy.asarray(query_tokens_ids_single, dtype=int_dtype)
+        if union_mode == "stamp_slots":
+            count_kernel(
+                (grid_size,),
+                (block_size,),
+                (
+                    candidates,
+                    np.int32(n_score_slots),
+                    count_gpu,
+                    query_terms_gpu,
+                    np.int32(len(query_tokens_ids_single)),
+                    data_gpu,
+                    indices_gpu,
+                    indptr_gpu,
+                    candidate_scores,
+                ),
+            )
+        else:
+            kernel(
+                (grid_size,),
+                (block_size,),
+                (
+                    candidates,
+                    np.int32(n_candidates),
+                    query_terms_gpu,
+                    np.int32(len(query_tokens_ids_single)),
+                    data_gpu,
+                    indices_gpu,
+                    indptr_gpu,
+                    candidate_scores,
+                ),
+            )
+
+        topk_scores, topk_docs_pos = _topk_cupy_gpu(
+            candidate_scores, k=k, sorted=True
+        )
+        topk_docs = candidates[topk_docs_pos].astype(int_dtype, copy=False)
+        outside_bound = (
+            float(term_max[dropped_terms].sum()) if len(dropped_terms) else 0.0
+        )
+
+        retrieved_docs[query_pos] = topk_docs
+        retrieved_scores[query_pos] = topk_scores.astype(dtype, copy=False)
+        cert_candidate_positions.append(query_pos)
+        cert_topk_scores.append(topk_scores)
+        cert_outside_bounds.append(outside_bound)
+
+    fallback_positions.extend(
+        _resolve_candidate_certification(
+            candidate_positions=cert_candidate_positions,
+            topk_scores=cert_topk_scores,
+            outside_bounds=cert_outside_bounds,
+        )
+    )
+    for query_pos in fallback_positions:
+        retrieved_docs[query_pos] = None
+        retrieved_scores[query_pos] = None
+
+    if fallback_positions:
+        fallback_docs, fallback_scores = _retrieve_dense_batch_cupy(
+            [query_tokens_ids[pos] for pos in fallback_positions],
+            scores,
+            k=k,
+            sorted=True,
+            dtype=dtype,
+            int_dtype=int_dtype,
+        )
+        for fallback_idx, query_pos in enumerate(fallback_positions):
+            retrieved_docs[query_pos] = cupy.asarray(
+                fallback_docs[fallback_idx], dtype=int_dtype
+            )
+            retrieved_scores[query_pos] = cupy.asarray(
+                fallback_scores[fallback_idx], dtype=dtype
+            )
+
+    return (
+        cupy.asnumpy(cupy.stack(retrieved_docs)),
+        cupy.asnumpy(cupy.stack(retrieved_scores)),
+    )
 
 
 def _score_query_cupy(
@@ -54,6 +1166,7 @@ def _retrieve_cupy_functional(
     int_dtype="int32",
     weight_mask=None,
 ):
+    global _WARNED_IGNORED_CHUNKSIZE, _WARNED_IGNORED_N_THREADS
     cupy = _require_cupy()
 
     if backend_selection == "auto":
@@ -66,17 +1179,19 @@ def _retrieve_cupy_functional(
         )
         raise ValueError(error_msg)
 
-    if chunksize is not None:
+    if chunksize is not None and not _WARNED_IGNORED_CHUNKSIZE:
         logging.warning(
             "The `chunksize` parameter is ignored in the `retrieve` function "
             "when using the `cupy` backend."
         )
+        _WARNED_IGNORED_CHUNKSIZE = True
 
-    if n_threads not in (0, 1):
+    if n_threads not in (0, 1) and not _WARNED_IGNORED_N_THREADS:
         logging.warning(
             "The `n_threads` parameter is ignored in the `retrieve` function "
             "when using the `cupy` backend."
         )
+        _WARNED_IGNORED_N_THREADS = True
 
     allowed_return_as = ["tuple", "documents"]
     if return_as not in allowed_return_as:
@@ -86,9 +1201,10 @@ def _retrieve_cupy_functional(
     int_dtype = np.dtype(int_dtype)
     num_queries = len(query_tokens_ids)
 
-    data_gpu = cupy.asarray(scores["data"], dtype=dtype)
-    indices_gpu = cupy.asarray(scores["indices"], dtype=int_dtype)
-    indptr = np.asarray(scores["indptr"], dtype=int_dtype)
+    cache = _get_cupy_index_cache(scores, dtype=dtype, int_dtype=int_dtype)
+    data_gpu = cache["data"]
+    indices_gpu = cache["indices"]
+    indptr = cache["indptr_cpu"]
 
     if nonoccurrence_array is not None:
         nonoccurrence_array_gpu = cupy.asarray(nonoccurrence_array, dtype=dtype)
@@ -100,27 +1216,51 @@ def _retrieve_cupy_functional(
     else:
         weight_mask_gpu = None
 
-    retrieved_scores = np.empty((num_queries, k), dtype=dtype)
-    retrieved_indices = np.empty((num_queries, k), dtype=int_dtype)
-
-    for i, query_tokens_ids_single in enumerate(query_tokens_ids):
-        query_tokens_ids_single = np.asarray(query_tokens_ids_single, dtype=int_dtype)
-        scores_single = _score_query_cupy(
-            query_tokens_ids=query_tokens_ids_single,
-            data=data_gpu,
-            indices=indices_gpu,
-            indptr=indptr,
-            num_docs=scores["num_docs"],
+    sparse_result = None
+    if sorted and nonoccurrence_array is None and weight_mask is None:
+        max_postings = int(
+            os.environ.get("BM25S_CUPY_SPARSE_MAX_POSTINGS", "50000000")
+        )
+        sparse_result = _retrieve_sparse_batch_cupy(
+            query_tokens_ids=query_tokens_ids,
+            scores=scores,
+            k=k,
             dtype=dtype,
-            nonoccurrence_array=nonoccurrence_array_gpu,
-            weight_mask=weight_mask_gpu,
+            int_dtype=int_dtype,
+            max_postings=max_postings,
         )
 
-        topk_scores_sing, topk_indices_sing = topk(
-            scores_single, k=k, backend="cupy", sorted=sorted
-        )
-        retrieved_scores[i] = topk_scores_sing.astype(dtype, copy=False)
-        retrieved_indices[i] = topk_indices_sing.astype(int_dtype, copy=False)
+    if sparse_result is not None:
+        retrieved_indices, retrieved_scores = sparse_result
+    else:
+        candidate_result = None
+        if sorted and nonoccurrence_array is None and weight_mask is None:
+            df_threshold = int(
+                os.environ.get("BM25S_CUPY_CANDIDATE_DF_THRESHOLD", "75000")
+            )
+            if df_threshold > 0:
+                candidate_result = _retrieve_candidate_batch_cupy(
+                    query_tokens_ids=query_tokens_ids,
+                    scores=scores,
+                    k=k,
+                    dtype=dtype,
+                    int_dtype=int_dtype,
+                    df_threshold=df_threshold,
+                )
+
+        if candidate_result is not None:
+            retrieved_indices, retrieved_scores = candidate_result
+        else:
+            retrieved_indices, retrieved_scores = _retrieve_dense_batch_cupy(
+                query_tokens_ids=query_tokens_ids,
+                scores=scores,
+                k=k,
+                sorted=sorted,
+                dtype=dtype,
+                int_dtype=int_dtype,
+                nonoccurrence_array=nonoccurrence_array_gpu,
+                weight_mask=weight_mask_gpu,
+            )
 
     if corpus is None:
         retrieved_docs = retrieved_indices

--- a/bm25s/cupy/selection.py
+++ b/bm25s/cupy/selection.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+
+try:
+    import cupy as cp
+except Exception:
+    cp = None
+    CUPY_AVAILABLE = False
+else:
+    CUPY_AVAILABLE = True
+
+
+def _require_cupy():
+    if cp is None:
+        raise ImportError(
+            "CuPy is not installed. Please install a CuPy package compatible with "
+            "your CUDA runtime to use the cupy backend."
+        )
+    return cp
+
+
+def _topk_cupy(query_scores, k, sorted):
+    cupy = _require_cupy()
+
+    query_scores_gpu = cupy.asarray(query_scores)
+    n_scores = int(query_scores_gpu.shape[0])
+    if k > n_scores:
+        k = n_scores
+
+    if k == 0:
+        scores_dtype = np.asarray(query_scores).dtype
+        return np.empty(0, dtype=scores_dtype), np.empty(0, dtype=np.int64)
+
+    partitioned_ind = cupy.argpartition(query_scores_gpu, -k)
+    partitioned_ind = partitioned_ind.take(indices=range(-k, 0))
+    partitioned_scores = cupy.take(query_scores_gpu, partitioned_ind)
+
+    if sorted:
+        sorted_trunc_ind = cupy.flip(cupy.argsort(partitioned_scores))
+        ind = partitioned_ind[sorted_trunc_ind]
+        query_scores_gpu = partitioned_scores[sorted_trunc_ind]
+    else:
+        ind = partitioned_ind
+        query_scores_gpu = partitioned_scores
+
+    return cupy.asnumpy(query_scores_gpu), cupy.asnumpy(ind)
+
+
+def topk(query_scores, k, backend="cupy", sorted=True):
+    """
+    Retrieve the top-k results for a single 1-dimensional score array with CuPy.
+    """
+    if backend != "cupy":
+        raise ValueError("Invalid backend. Only 'cupy' is supported.")
+
+    return _topk_cupy(query_scores, k, sorted)

--- a/bm25s/cupy/selection.py
+++ b/bm25s/cupy/selection.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 
 
@@ -23,13 +25,44 @@ def _topk_cupy(query_scores, k, sorted):
     cupy = _require_cupy()
 
     query_scores_gpu = cupy.asarray(query_scores)
+    query_scores_gpu, ind = _topk_cupy_gpu(query_scores_gpu, k, sorted)
+    return cupy.asnumpy(query_scores_gpu), cupy.asnumpy(ind)
+
+
+def _topk_cupy_gpu(query_scores_gpu, k, sorted):
+    cupy = _require_cupy()
+
+    query_scores_gpu = cupy.asarray(query_scores_gpu)
     n_scores = int(query_scores_gpu.shape[0])
     if k > n_scores:
         k = n_scores
 
     if k == 0:
-        scores_dtype = np.asarray(query_scores).dtype
-        return np.empty(0, dtype=scores_dtype), np.empty(0, dtype=np.int64)
+        return (
+            cupy.empty(0, dtype=query_scores_gpu.dtype),
+            cupy.empty(0, dtype=cupy.int64),
+        )
+
+    if os.environ.get("BM25S_CUPY_TOPK_MODE", "sort") == "sort":
+        return _topk_cupy_sort_gpu(query_scores_gpu, k, sorted)
+
+    return _topk_cupy_partition_gpu(query_scores_gpu, k, sorted)
+
+
+def _topk_cupy_sort_gpu(query_scores_gpu, k, sorted):
+    cupy = _require_cupy()
+
+    order = cupy.argsort(query_scores_gpu)
+    ind = order[-k:]
+    if sorted:
+        ind = ind[::-1]
+
+    query_scores_gpu = cupy.take(query_scores_gpu, ind)
+    return query_scores_gpu, ind
+
+
+def _topk_cupy_partition_gpu(query_scores_gpu, k, sorted):
+    cupy = _require_cupy()
 
     partitioned_ind = cupy.argpartition(query_scores_gpu, -k)
     partitioned_ind = partitioned_ind.take(indices=range(-k, 0))
@@ -43,7 +76,7 @@ def _topk_cupy(query_scores, k, sorted):
         ind = partitioned_ind
         query_scores_gpu = partitioned_scores
 
-    return cupy.asnumpy(query_scores_gpu), cupy.asnumpy(ind)
+    return query_scores_gpu, ind
 
 
 def topk(query_scores, k, backend="cupy", sorted=True):

--- a/bm25s/selection.py
+++ b/bm25s/selection.py
@@ -10,6 +10,14 @@ else:
     # any output to avoid it from saying that gpu is not available
     _ = jax.lax.top_k(np.array([0] * 5), 1)
 
+try:
+    from .cupy import selection as selection_cupy
+except ImportError:
+    selection_cupy = None
+    CUPY_IS_AVAILABLE = False
+else:
+    CUPY_IS_AVAILABLE = selection_cupy.CUPY_AVAILABLE
+
 
 def _topk_numpy(query_scores, k, sorted):
     # https://stackoverflow.com/questions/65038206/how-to-get-indices-of-top-k-values-from-a-numpy-array
@@ -54,11 +62,18 @@ def topk(query_scores, k, backend="auto", sorted=True):
         # if jax.lax is available, use it to speed up selection, otherwise use numpy
         backend = "jax" if JAX_IS_AVAILABLE else "numpy"
     
-    if backend not in ["numpy", "jax"]:
-        raise ValueError("Invalid backend. Please choose from 'numpy' or 'jax'.")
+    if backend not in ["numpy", "jax", "cupy"]:
+        raise ValueError("Invalid backend. Please choose from 'numpy', 'jax', or 'cupy'.")
     elif backend == "jax":
         if not JAX_IS_AVAILABLE:
             raise ImportError("JAX is not available. Please install JAX with `pip install jax[cpu]` to use this backend.")
         return _topk_jax(query_scores, k)
+    elif backend == "cupy":
+        if not CUPY_IS_AVAILABLE or selection_cupy is None:
+            raise ImportError(
+                "CuPy is not installed. Please install a CuPy package compatible "
+                "with your CUDA runtime to use this backend."
+            )
+        return selection_cupy.topk(query_scores, k, backend="cupy", sorted=sorted)
     else:
         return _topk_numpy(query_scores, k, sorted)

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,6 +17,15 @@ For numba, you have to run:
 python -m unittest tests/numba/*.py
 ```
 
+For CuPy, install the CuPy package matching your CUDA runtime and run:
+
+```bash
+python -m unittest discover tests/cupy
+```
+
+On machines without CuPy or a CUDA runtime, the GPU behavior tests are skipped
+and the missing-dependency tests still run.
+
 
 ## Basic Comparisons
 
@@ -34,6 +43,7 @@ To run the core tests (of library), simply run the following command:
 python -m unittest tests/core/*.py
 python -m unittest tests/stopwords/*.py
 python -m unittest tests/numba/*.py
+python -m unittest discover tests/cupy
 python -m unittest tests/comparison/*.py
 ```
 

--- a/tests/core/test_init_utils.py
+++ b/tests/core/test_init_utils.py
@@ -73,6 +73,15 @@ class TestBM25SUtilityFunctions(unittest.TestCase):
         self.assertIn("foo", unique)
         self.assertIn("bar", unique)
 
+    def test_get_tokens_ids_keeps_zero_id_and_drops_unknown_tokens(self):
+        retriever = bm25s.BM25()
+        retriever.vocab_dict = {"known-zero": 0, "known-one": 1}
+
+        self.assertEqual(
+            retriever.get_tokens_ids(["known-zero", "missing", "known-one"]),
+            [0, 1],
+        )
+
     def test_faketqdm_when_tqdm_disabled(self):
         """Test that fake tqdm works when DISABLE_TQDM is set"""
         # Save original value

--- a/tests/core/test_tokenizer_misc.py
+++ b/tests/core/test_tokenizer_misc.py
@@ -68,10 +68,9 @@ class TestBM25SNewIds(unittest.TestCase):
         self.assertListEqual([[27, 2, 0, 28]], query_tokens)
 
         results, scores = bm25.retrieve(query_tokens, k=3)
-        self.assertTrue(
-            np.all(np.array([[0, 2, 3]]) == results),
-            msg=f"Results differ from expected: {results}, {scores}",
-        )
+        self.assertEqual({0, 2}, set(results[0, :2]))
+        self.assertEqual(3, results[0, 2])
+        np.testing.assert_allclose(scores[0, 0], scores[0, 1])
 
     def test_failing_after_adding_new_tokens_query(self):
         corpus = [

--- a/tests/cupy/test_cupy_backend_retrieve.py
+++ b/tests/cupy/test_cupy_backend_retrieve.py
@@ -1,0 +1,235 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+import Stemmer
+
+import bm25s
+
+
+def _cupy_runtime_available():
+    try:
+        import cupy as cp
+
+        cp.cuda.runtime.getDeviceCount()
+        cp.asnumpy(cp.asarray([1], dtype=cp.float32))
+    except Exception as exc:
+        return False, f"CuPy runtime is not available: {exc}"
+    return True, ""
+
+
+CUPY_AVAILABLE, CUPY_SKIP_REASON = _cupy_runtime_available()
+
+
+@unittest.skipUnless(CUPY_AVAILABLE, CUPY_SKIP_REASON)
+class TestCuPyBackendRetrieve(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        corpus = [
+            "a cat is a feline and likes to purr",
+            "a dog is the human's best friend and loves to play",
+            "a bird is a beautiful animal that can fly",
+            "a fish is a creature that lives in water and swims",
+        ]
+
+        stemmer = Stemmer.Stemmer("english")
+        corpus_tokens = bm25s.tokenize(corpus, stopwords="en", stemmer=stemmer)
+
+        retriever = bm25s.BM25(method="bm25+", backend="cupy", corpus=corpus)
+        retriever.index(corpus_tokens)
+
+        cls.retriever = retriever
+        cls.corpus = corpus
+        cls.corpus_tokens = corpus_tokens
+        cls.stemmer = stemmer
+        cls.tmpdirname = tempfile.mkdtemp()
+
+    def test_a_save(self):
+        self.retriever.save(
+            self.tmpdirname,
+            data_name="data.index.csc.npy",
+            indices_name="indices.index.csc.npy",
+            indptr_name="indptr.index.csc.npy",
+            vocab_name="vocab.json",
+            nnoc_name="nonoccurrence_array.npy",
+            params_name="params.json",
+        )
+
+        fnames = [
+            "data.index.csc.npy",
+            "indices.index.csc.npy",
+            "indptr.index.csc.npy",
+            "vocab.json",
+            "nonoccurrence_array.npy",
+            "params.json",
+        ]
+
+        for fname in fnames:
+            error_msg = (
+                f"File {fname} not found even though it should be saved by .save()"
+            )
+            path_exists = os.path.exists(os.path.join(self.tmpdirname, fname))
+            self.assertTrue(path_exists, error_msg)
+
+    def test_b_retrieve_with_cupy(self):
+        retriever = bm25s.BM25.load(
+            self.tmpdirname,
+            data_name="data.index.csc.npy",
+            indices_name="indices.index.csc.npy",
+            indptr_name="indptr.index.csc.npy",
+            vocab_name="vocab.json",
+            nnoc_name="nonoccurrence_array.npy",
+            params_name="params.json",
+            load_corpus=True,
+        )
+
+        self.assertTrue(retriever.backend == "cupy", "The backend should be 'cupy'")
+
+        reloaded_corpus_text = [c["text"] for c in retriever.corpus]
+        self.assertTrue(
+            reloaded_corpus_text == self.corpus,
+            "The corpus should be the same as the original corpus",
+        )
+
+        query = ["my cat loves to purr", "a fish likes swimming"]
+        query_tokens = bm25s.tokenize(query, stopwords="en", stemmer=self.stemmer)
+
+        top_k = 2
+        retrieved = retriever.retrieve(query_tokens, k=top_k, return_as="tuple")
+        retrieved_docs = retriever.retrieve(query_tokens, k=top_k, return_as="documents")
+
+        retriever.backend = "numpy"
+        retrieved_np = retriever.retrieve(
+            query_tokens,
+            k=top_k,
+            return_as="tuple",
+            backend_selection="numpy",
+        )
+        retrieved_docs_np = retriever.retrieve(
+            query_tokens,
+            k=top_k,
+            return_as="documents",
+            backend_selection="numpy",
+        )
+        retrieved_cupy_selection = retriever.retrieve(
+            query_tokens,
+            k=top_k,
+            return_as="tuple",
+            backend_selection="cupy",
+        )
+
+        np.testing.assert_allclose(retrieved.scores, retrieved_np.scores)
+        np.testing.assert_array_equal(retrieved.documents, retrieved_np.documents)
+        np.testing.assert_array_equal(retrieved_docs, retrieved_docs_np)
+        np.testing.assert_allclose(
+            retrieved_cupy_selection.scores, retrieved_np.scores
+        )
+        np.testing.assert_array_equal(
+            retrieved_cupy_selection.documents, retrieved_np.documents
+        )
+
+    def test_c_mmap_retrieve_with_cupy(self):
+        retriever = bm25s.BM25.load(
+            self.tmpdirname,
+            data_name="data.index.csc.npy",
+            indices_name="indices.index.csc.npy",
+            indptr_name="indptr.index.csc.npy",
+            vocab_name="vocab.json",
+            nnoc_name="nonoccurrence_array.npy",
+            params_name="params.json",
+            load_corpus=True,
+            mmap=True,
+        )
+
+        self.assertTrue(retriever.backend == "cupy", "The backend should be 'cupy'")
+
+        reloaded_corpus_text = [c["text"] for c in retriever.corpus]
+        self.assertTrue(
+            reloaded_corpus_text == self.corpus,
+            "The corpus should be the same as the original corpus",
+        )
+
+        query = ["my cat loves to purr", "a fish likes swimming"]
+        query_tokens = bm25s.tokenize(query, stopwords="en", stemmer=self.stemmer)
+
+        top_k = 2
+        retrieved = retriever.retrieve(query_tokens, k=top_k, return_as="tuple")
+        retrieved_docs = retriever.retrieve(query_tokens, k=top_k, return_as="documents")
+
+        retriever.backend = "numpy"
+        retrieved_np = retriever.retrieve(
+            query_tokens,
+            k=top_k,
+            return_as="tuple",
+            backend_selection="numpy",
+        )
+        retrieved_docs_np = retriever.retrieve(
+            query_tokens,
+            k=top_k,
+            return_as="documents",
+            backend_selection="numpy",
+        )
+        retrieved_cupy_selection = retriever.retrieve(
+            query_tokens,
+            k=top_k,
+            return_as="tuple",
+            backend_selection="cupy",
+        )
+
+        np.testing.assert_allclose(retrieved.scores, retrieved_np.scores)
+        np.testing.assert_array_equal(retrieved.documents, retrieved_np.documents)
+        np.testing.assert_array_equal(retrieved_docs, retrieved_docs_np)
+        np.testing.assert_allclose(
+            retrieved_cupy_selection.scores, retrieved_np.scores
+        )
+        np.testing.assert_array_equal(
+            retrieved_cupy_selection.documents, retrieved_np.documents
+        )
+
+    def test_d_retrieve_with_weight_mask(self):
+        for dt in [np.float32, np.int32, np.bool_]:
+            weight_mask = np.array([1, 1, 0, 1], dtype=dt)
+            retriever = bm25s.BM25.load(
+                self.tmpdirname,
+                data_name="data.index.csc.npy",
+                indices_name="indices.index.csc.npy",
+                indptr_name="indptr.index.csc.npy",
+                vocab_name="vocab.json",
+                nnoc_name="nonoccurrence_array.npy",
+                params_name="params.json",
+                load_corpus=True,
+            )
+
+            self.assertTrue(
+                retriever.backend == "cupy", "The backend should be 'cupy'"
+            )
+
+            query = ["my cat loves to purr", "a fish likes swimming"]
+            query_tokens = bm25s.tokenize(query, stopwords="en", stemmer=self.stemmer)
+
+            top_k = 2
+            retrieved = retriever.retrieve(
+                query_tokens, k=top_k, return_as="tuple", weight_mask=weight_mask
+            )
+
+            retriever.backend = "numpy"
+            retrieved_np = retriever.retrieve(
+                query_tokens,
+                k=top_k,
+                return_as="tuple",
+                weight_mask=weight_mask,
+                backend_selection="numpy",
+            )
+
+            np.testing.assert_allclose(retrieved.scores, retrieved_np.scores)
+            np.testing.assert_array_equal(retrieved.documents, retrieved_np.documents)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpdirname)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cupy/test_cupy_backend_retrieve.py
+++ b/tests/cupy/test_cupy_backend_retrieve.py
@@ -4,7 +4,6 @@ import tempfile
 import unittest
 
 import numpy as np
-import Stemmer
 
 import bm25s
 
@@ -34,8 +33,7 @@ class TestCuPyBackendRetrieve(unittest.TestCase):
             "a fish is a creature that lives in water and swims",
         ]
 
-        stemmer = Stemmer.Stemmer("english")
-        corpus_tokens = bm25s.tokenize(corpus, stopwords="en", stemmer=stemmer)
+        corpus_tokens = bm25s.tokenize(corpus, stopwords="en")
 
         retriever = bm25s.BM25(method="bm25+", backend="cupy", corpus=corpus)
         retriever.index(corpus_tokens)
@@ -43,7 +41,6 @@ class TestCuPyBackendRetrieve(unittest.TestCase):
         cls.retriever = retriever
         cls.corpus = corpus
         cls.corpus_tokens = corpus_tokens
-        cls.stemmer = stemmer
         cls.tmpdirname = tempfile.mkdtemp()
 
     def test_a_save(self):
@@ -94,7 +91,7 @@ class TestCuPyBackendRetrieve(unittest.TestCase):
         )
 
         query = ["my cat loves to purr", "a fish likes swimming"]
-        query_tokens = bm25s.tokenize(query, stopwords="en", stemmer=self.stemmer)
+        query_tokens = bm25s.tokenize(query, stopwords="en")
 
         top_k = 2
         retrieved = retriever.retrieve(query_tokens, k=top_k, return_as="tuple")
@@ -152,7 +149,7 @@ class TestCuPyBackendRetrieve(unittest.TestCase):
         )
 
         query = ["my cat loves to purr", "a fish likes swimming"]
-        query_tokens = bm25s.tokenize(query, stopwords="en", stemmer=self.stemmer)
+        query_tokens = bm25s.tokenize(query, stopwords="en")
 
         top_k = 2
         retrieved = retriever.retrieve(query_tokens, k=top_k, return_as="tuple")
@@ -207,7 +204,7 @@ class TestCuPyBackendRetrieve(unittest.TestCase):
             )
 
             query = ["my cat loves to purr", "a fish likes swimming"]
-            query_tokens = bm25s.tokenize(query, stopwords="en", stemmer=self.stemmer)
+            query_tokens = bm25s.tokenize(query, stopwords="en")
 
             top_k = 2
             retrieved = retriever.retrieve(

--- a/tests/cupy/test_cupy_candidate_batch_retrieve.py
+++ b/tests/cupy/test_cupy_candidate_batch_retrieve.py
@@ -1,0 +1,286 @@
+import unittest
+
+import numpy as np
+
+
+def _cupy_runtime_available():
+    try:
+        import cupy as cp
+
+        cp.cuda.runtime.getDeviceCount()
+        cp.asnumpy(cp.asarray([1], dtype=cp.float32))
+    except Exception as exc:
+        return False, f"CuPy runtime is not available: {exc}"
+    return True, ""
+
+
+CUPY_AVAILABLE, CUPY_SKIP_REASON = _cupy_runtime_available()
+
+
+@unittest.skipUnless(CUPY_AVAILABLE, CUPY_SKIP_REASON)
+class TestCuPyCandidateBatchRetrieve(unittest.TestCase):
+    def test_candidate_terms_from_query_deduplicates_kept_terms_only(self):
+        from bm25s.cupy.retrieve_utils import _candidate_terms_from_query
+
+        indptr = np.asarray([0, 2, 8, 11, 20], dtype=np.int32)
+        query_terms = np.asarray([0, 1, 1, 2, 3, 3], dtype=np.int32)
+
+        candidate_terms, dropped_terms = _candidate_terms_from_query(
+            query_terms=query_terms,
+            indptr_cpu=indptr,
+            df_threshold=5,
+        )
+
+        np.testing.assert_array_equal(
+            candidate_terms, np.asarray([0, 2], dtype=np.int32)
+        )
+        np.testing.assert_array_equal(
+            dropped_terms, np.asarray([1, 1, 3, 3], dtype=np.int32)
+        )
+
+    def test_resolve_candidate_certification_batches_kth_transfer(self):
+        import cupy as cp
+
+        from bm25s.cupy.retrieve_utils import _resolve_candidate_certification
+
+        topk_scores = [
+            cp.asarray([4.0, 3.0, 2.0], dtype=cp.float32),
+            cp.asarray([7.0, 6.0, 5.0], dtype=cp.float32),
+        ]
+
+        fallback_positions = _resolve_candidate_certification(
+            candidate_positions=[10, 20],
+            topk_scores=topk_scores,
+            outside_bounds=[1.5, 5.0],
+        )
+
+        self.assertEqual(fallback_positions, [20])
+
+    def test_build_candidates_atomic_cupy_returns_unique_docs_and_clears_marks(self):
+        import cupy as cp
+
+        from bm25s.cupy.retrieve_utils import _build_candidates_atomic_cupy
+
+        # term 0 -> docs [0, 2, 3], term 1 -> docs [2, 4].
+        indices_gpu = cp.asarray([0, 2, 3, 2, 4], dtype=cp.int32)
+        indptr_cpu = np.asarray([0, 3, 5], dtype=np.int32)
+        marks_gpu = cp.zeros(5, dtype=cp.int32)
+        count_gpu = cp.zeros(1, dtype=cp.int32)
+
+        candidates = _build_candidates_atomic_cupy(
+            candidate_terms=np.asarray([0, 1], dtype=np.int32),
+            indptr_cpu=indptr_cpu,
+            indices_gpu=indices_gpu,
+            marks_gpu=marks_gpu,
+            count_gpu=count_gpu,
+        )
+
+        np.testing.assert_array_equal(
+            np.sort(cp.asnumpy(candidates)),
+            np.asarray([0, 2, 3, 4], dtype=np.int32),
+        )
+        np.testing.assert_array_equal(cp.asnumpy(marks_gpu), np.zeros(5, dtype=np.int32))
+
+    def test_build_candidates_stamp_cupy_reuses_marks_without_clearing(self):
+        import cupy as cp
+
+        from bm25s.cupy.retrieve_utils import _build_candidates_stamp_cupy
+
+        indices_gpu = cp.asarray([0, 2, 3, 2, 4], dtype=cp.int32)
+        indptr_cpu = np.asarray([0, 3, 5], dtype=np.int32)
+        marks_gpu = cp.zeros(5, dtype=cp.int32)
+        count_gpu = cp.zeros(1, dtype=cp.int32)
+
+        first = _build_candidates_stamp_cupy(
+            candidate_terms=np.asarray([0, 1], dtype=np.int32),
+            indptr_cpu=indptr_cpu,
+            indices_gpu=indices_gpu,
+            marks_gpu=marks_gpu,
+            count_gpu=count_gpu,
+            stamp=1,
+        )
+        second = _build_candidates_stamp_cupy(
+            candidate_terms=np.asarray([1], dtype=np.int32),
+            indptr_cpu=indptr_cpu,
+            indices_gpu=indices_gpu,
+            marks_gpu=marks_gpu,
+            count_gpu=count_gpu,
+            stamp=2,
+        )
+
+        np.testing.assert_array_equal(
+            np.sort(cp.asnumpy(first)),
+            np.asarray([0, 2, 3, 4], dtype=np.int32),
+        )
+        np.testing.assert_array_equal(
+            np.sort(cp.asnumpy(second)),
+            np.asarray([2, 4], dtype=np.int32),
+        )
+
+    def test_build_candidates_stamp_slots_cupy_keeps_count_on_device(self):
+        import cupy as cp
+
+        from bm25s.cupy.retrieve_utils import _build_candidates_stamp_slots_cupy
+
+        indices_gpu = cp.asarray([0, 2, 3, 2, 4], dtype=cp.int32)
+        indptr_cpu = np.asarray([0, 3, 5], dtype=np.int32)
+        marks_gpu = cp.zeros(5, dtype=cp.int32)
+        count_gpu = cp.zeros(1, dtype=cp.int32)
+
+        candidates, total_slots, returned_count = _build_candidates_stamp_slots_cupy(
+            candidate_terms=np.asarray([0, 1], dtype=np.int32),
+            indptr_cpu=indptr_cpu,
+            indices_gpu=indices_gpu,
+            marks_gpu=marks_gpu,
+            count_gpu=count_gpu,
+            stamp=1,
+        )
+
+        self.assertEqual(total_slots, 5)
+        self.assertIs(returned_count, count_gpu)
+        self.assertEqual(int(cp.asnumpy(count_gpu)[0]), 4)
+        np.testing.assert_array_equal(
+            np.sort(cp.asnumpy(candidates[:4])),
+            np.asarray([0, 2, 3, 4], dtype=np.int32),
+        )
+
+    def test_unique_sorted_cupy_matches_cupy_unique(self):
+        import cupy as cp
+
+        from bm25s.cupy.retrieve_utils import _unique_sorted_cupy
+
+        values = cp.asarray([4, 2, 4, 1, 2, 7, 1], dtype=cp.int32)
+        result = _unique_sorted_cupy(values)
+
+        np.testing.assert_array_equal(
+            cp.asnumpy(result), np.asarray([1, 2, 4, 7], dtype=np.int32)
+        )
+
+    def test_candidate_batch_scores_candidates_with_all_query_terms(self):
+        import os
+
+        from bm25s.cupy.retrieve_utils import _retrieve_candidate_batch_cupy
+
+        # CSC score matrix with shape docs x terms.
+        # term 0 is the low-df candidate generator.
+        # term 1 is a high-df scoring-only term and must still affect ranking.
+        scores = {
+            "data": np.asarray([5, 4, 0, 10, 1], dtype=np.float32),
+            "indices": np.asarray([0, 1, 0, 1, 2], dtype=np.int32),
+            "indptr": np.asarray([0, 2, 5], dtype=np.int32),
+            "num_docs": 3,
+        }
+        query_tokens_ids = [np.asarray([0, 1], dtype=np.int32)]
+        old = os.environ.get("BM25S_CUPY_CANDIDATE_UNION")
+        os.environ["BM25S_CUPY_CANDIDATE_UNION"] = "stamp_slots"
+        try:
+            docs, returned_scores = _retrieve_candidate_batch_cupy(
+                query_tokens_ids=query_tokens_ids,
+                scores=scores,
+                k=1,
+                dtype=np.dtype("float32"),
+                int_dtype=np.dtype("int32"),
+                df_threshold=2,
+            )
+        finally:
+            if old is None:
+                os.environ.pop("BM25S_CUPY_CANDIDATE_UNION", None)
+            else:
+                os.environ["BM25S_CUPY_CANDIDATE_UNION"] = old
+
+        np.testing.assert_array_equal(docs, np.asarray([[1]], dtype=np.int32))
+        np.testing.assert_allclose(
+            returned_scores, np.asarray([[14]], dtype=np.float32)
+        )
+
+    def test_spmm_candidate_batch_matches_candidate_path_with_dropped_terms(self):
+        from bm25s.cupy.retrieve_utils import (
+            _retrieve_candidate_batch_cupy,
+            _retrieve_spmm_batch_cupy,
+        )
+
+        scores = {
+            "data": np.asarray([5, 4, 0, 10, 1], dtype=np.float32),
+            "indices": np.asarray([0, 1, 0, 1, 2], dtype=np.int32),
+            "indptr": np.asarray([0, 2, 5], dtype=np.int32),
+            "num_docs": 3,
+        }
+        query_tokens_ids = [np.asarray([0, 1], dtype=np.int32)]
+
+        expected_docs, expected_scores = _retrieve_candidate_batch_cupy(
+            query_tokens_ids=query_tokens_ids,
+            scores=scores,
+            k=1,
+            dtype=np.dtype("float32"),
+            int_dtype=np.dtype("int32"),
+            df_threshold=2,
+        )
+        docs, returned_scores = _retrieve_spmm_batch_cupy(
+            query_tokens_ids=query_tokens_ids,
+            scores=scores,
+            k=1,
+            dtype=np.dtype("float32"),
+            int_dtype=np.dtype("int32"),
+            df_threshold=2,
+            batch_size=8,
+        )
+
+        np.testing.assert_array_equal(docs, expected_docs)
+        np.testing.assert_allclose(returned_scores, expected_scores)
+
+    def test_spmm_candidate_batch_scores_duplicate_low_df_terms(self):
+        from bm25s.cupy.retrieve_utils import _retrieve_spmm_batch_cupy
+
+        scores = {
+            "data": np.asarray([5, 4, 1], dtype=np.float32),
+            "indices": np.asarray([0, 1, 2], dtype=np.int32),
+            "indptr": np.asarray([0, 2, 3], dtype=np.int32),
+            "num_docs": 3,
+        }
+
+        docs, returned_scores = _retrieve_spmm_batch_cupy(
+            query_tokens_ids=[np.asarray([0, 0, 1], dtype=np.int32)],
+            scores=scores,
+            k=2,
+            dtype=np.dtype("float32"),
+            int_dtype=np.dtype("int32"),
+            df_threshold=2,
+            batch_size=8,
+        )
+
+        np.testing.assert_array_equal(docs, np.asarray([[0, 1]], dtype=np.int32))
+        np.testing.assert_allclose(returned_scores, np.asarray([[10, 8]], dtype=np.float32))
+
+    def test_topk_from_csr_rows_accepts_precomputed_cpu_indptr(self):
+        import cupy as cp
+        import cupyx.scipy.sparse as cpsp
+
+        from bm25s.cupy.retrieve_utils import _topk_from_csr_rows_cupy
+
+        matrix = cpsp.csr_matrix(
+            (
+                cp.asarray([1.0, 3.0, 2.0, 4.0], dtype=cp.float32),
+                cp.asarray([10, 11, 12, 13], dtype=cp.int32),
+                cp.asarray([0, 3, 4], dtype=cp.int32),
+            ),
+            shape=(2, 20),
+        )
+        indptr_cpu = cp.asnumpy(matrix.indptr)
+
+        docs_rows, score_rows, fallback_rows = _topk_from_csr_rows_cupy(
+            matrix,
+            k=2,
+            dtype=np.dtype("float32"),
+            int_dtype=np.dtype("int32"),
+            indptr_cpu=indptr_cpu,
+        )
+
+        self.assertEqual(fallback_rows, [1])
+        np.testing.assert_array_equal(cp.asnumpy(docs_rows[0]), np.asarray([11, 12], dtype=np.int32))
+        np.testing.assert_allclose(cp.asnumpy(score_rows[0]), np.asarray([3.0, 2.0], dtype=np.float32))
+        self.assertIsNone(docs_rows[1])
+        self.assertIsNone(score_rows[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cupy/test_cupy_missing_dependency.py
+++ b/tests/cupy/test_cupy_missing_dependency.py
@@ -1,0 +1,49 @@
+import unittest
+
+import numpy as np
+
+import bm25s
+from bm25s.selection import topk
+
+
+try:
+    import cupy  # noqa: F401
+except Exception:
+    CUPY_INSTALLED = False
+else:
+    CUPY_INSTALLED = True
+
+
+@unittest.skipIf(CUPY_INSTALLED, "CuPy is installed")
+class TestCuPyMissingDependency(unittest.TestCase):
+    def test_topk_cupy_backend_raises_import_error(self):
+        query_scores = np.array([3.0, 1.0, 4.0, 2.0], dtype=np.float32)
+
+        with self.assertRaises(ImportError) as context:
+            topk(query_scores, k=2, backend="cupy")
+
+        self.assertIn("CuPy", str(context.exception))
+
+    def test_bm25_cupy_backend_raises_import_error(self):
+        with self.assertRaises(ImportError) as context:
+            bm25s.BM25(backend="cupy")
+
+        self.assertIn("CuPy", str(context.exception))
+
+    def test_retrieve_cupy_selection_raises_import_error(self):
+        retriever = bm25s.BM25()
+        retriever.index([[0, 1], [1, 2]], show_progress=False)
+
+        with self.assertRaises(ImportError) as context:
+            retriever.retrieve(
+                [[1]],
+                k=1,
+                backend_selection="cupy",
+                show_progress=False,
+            )
+
+        self.assertIn("CuPy", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cupy/test_cupy_sparse_batch_retrieve.py
+++ b/tests/cupy/test_cupy_sparse_batch_retrieve.py
@@ -1,0 +1,56 @@
+import unittest
+
+import numpy as np
+
+
+def _cupy_runtime_available():
+    try:
+        import cupy as cp
+
+        cp.cuda.runtime.getDeviceCount()
+        cp.asnumpy(cp.asarray([1], dtype=cp.float32))
+    except Exception as exc:
+        return False, f"CuPy runtime is not available: {exc}"
+    return True, ""
+
+
+CUPY_AVAILABLE, CUPY_SKIP_REASON = _cupy_runtime_available()
+
+
+@unittest.skipUnless(CUPY_AVAILABLE, CUPY_SKIP_REASON)
+class TestCuPySparseBatchRetrieve(unittest.TestCase):
+    def test_sparse_batch_topk_accumulates_duplicate_terms(self):
+        from bm25s.cupy.retrieve_utils import _retrieve_sparse_batch_cupy
+
+        # CSC score matrix with shape docs x terms.
+        # term 0: doc 0 -> 1, doc 2 -> 2
+        # term 1: doc 1 -> 5, doc 2 -> 1
+        # term 2: doc 0 -> 4, doc 3 -> 3
+        scores = {
+            "data": np.asarray([1, 2, 5, 1, 4, 3], dtype=np.float32),
+            "indices": np.asarray([0, 2, 1, 2, 0, 3], dtype=np.int32),
+            "indptr": np.asarray([0, 2, 4, 6], dtype=np.int32),
+            "num_docs": 4,
+        }
+        query_tokens_ids = [
+            np.asarray([0, 1], dtype=np.int32),
+            np.asarray([0, 0, 2], dtype=np.int32),
+        ]
+
+        docs, returned_scores = _retrieve_sparse_batch_cupy(
+            query_tokens_ids=query_tokens_ids,
+            scores=scores,
+            k=2,
+            dtype=np.dtype("float32"),
+            int_dtype=np.dtype("int32"),
+            max_postings=100,
+        )
+
+        expected_docs = np.asarray([[1, 2], [0, 2]], dtype=np.int32)
+        expected_scores = np.asarray([[5, 3], [6, 4]], dtype=np.float32)
+        np.testing.assert_array_equal(docs, expected_docs)
+        np.testing.assert_allclose(returned_scores, expected_scores)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cupy/test_topk_cupy.py
+++ b/tests/cupy/test_topk_cupy.py
@@ -3,6 +3,8 @@ import unittest
 import numpy as np
 
 from bm25s.cupy.selection import topk as cupy_topk
+from bm25s.cupy.selection import _topk_cupy_gpu
+from bm25s.cupy.selection import _topk_cupy_sort_gpu
 from bm25s.selection import topk as public_topk
 
 
@@ -56,6 +58,38 @@ class TestTopKSingleQueryCuPy(unittest.TestCase):
             self.scores, self.k, backend="cupy", sorted=True
         )
         self.check_results(result_scores, result_indices, sorted=True)
+
+    def test_topk_cupy_gpu_keeps_results_on_device(self):
+        import cupy as cp
+
+        scores_gpu = cp.asarray(self.scores)
+        result_scores, result_indices = _topk_cupy_gpu(
+            scores_gpu, self.k, sorted=True
+        )
+
+        self.assertIsInstance(result_scores, cp.ndarray)
+        self.assertIsInstance(result_indices, cp.ndarray)
+        self.check_results(
+            cp.asnumpy(result_scores),
+            cp.asnumpy(result_indices),
+            sorted=True,
+        )
+
+    def test_topk_cupy_sort_gpu_matches_numpy_sorted_topk(self):
+        import cupy as cp
+
+        scores_gpu = cp.asarray(self.scores)
+        result_scores, result_indices = _topk_cupy_sort_gpu(
+            scores_gpu, self.k, sorted=True
+        )
+
+        self.assertIsInstance(result_scores, cp.ndarray)
+        self.assertIsInstance(result_indices, cp.ndarray)
+        self.check_results(
+            cp.asnumpy(result_scores),
+            cp.asnumpy(result_indices),
+            sorted=True,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/cupy/test_topk_cupy.py
+++ b/tests/cupy/test_topk_cupy.py
@@ -1,0 +1,62 @@
+import unittest
+
+import numpy as np
+
+from bm25s.cupy.selection import topk as cupy_topk
+from bm25s.selection import topk as public_topk
+
+
+def _cupy_runtime_available():
+    try:
+        import cupy as cp
+
+        cp.cuda.runtime.getDeviceCount()
+        cp.asnumpy(cp.asarray([1], dtype=cp.float32))
+    except Exception as exc:
+        return False, f"CuPy runtime is not available: {exc}"
+    return True, ""
+
+
+CUPY_AVAILABLE, CUPY_SKIP_REASON = _cupy_runtime_available()
+
+
+@unittest.skipUnless(CUPY_AVAILABLE, CUPY_SKIP_REASON)
+class TestTopKSingleQueryCuPy(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(42)
+        self.k = 5
+        self.scores = np.random.uniform(-10, 10, 2000).astype(np.float32)
+        self.expected_scores = np.sort(self.scores)[-self.k:][::-1]
+        self.expected_indices = np.argsort(self.scores)[-self.k:][::-1]
+
+    def check_results(self, result_scores, result_indices, sorted=True):
+        if sorted:
+            np.testing.assert_allclose(result_scores, self.expected_scores)
+            np.testing.assert_array_equal(result_indices, self.expected_indices)
+        else:
+            self.assertEqual(len(result_scores), self.k)
+            self.assertEqual(len(result_indices), self.k)
+            self.assertTrue(np.all(np.isin(result_scores, self.expected_scores)))
+            self.assertTrue(np.all(np.isin(result_indices, self.expected_indices)))
+
+    def test_topk_cupy_sorted(self):
+        result_scores, result_indices = cupy_topk(
+            self.scores, self.k, backend="cupy", sorted=True
+        )
+        self.check_results(result_scores, result_indices, sorted=True)
+
+    def test_topk_cupy_unsorted(self):
+        result_scores, result_indices = cupy_topk(
+            self.scores, self.k, backend="cupy", sorted=False
+        )
+        self.check_results(result_scores, result_indices, sorted=False)
+
+    def test_public_topk_accepts_cupy_backend(self):
+        result_scores, result_indices = public_topk(
+            self.scores, self.k, backend="cupy", sorted=True
+        )
+        self.check_results(result_scores, result_indices, sorted=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

  Add an explicit, opt-in CuPy backend for BM25 retrieval and top-k selection.

  This PR introduces `backend="cupy"` for GPU retrieval and `backend_selection="cupy"` for GPU top-k selection, while keeping `backend="auto"` unchanged: it still selects Numba when available and otherwise falls
  back to NumPy.

  ## What changed

  - Added `bm25s.cupy` with CuPy top-k selection and retrieval utilities.
  - Added CuPy retrieval support to `BM25.retrieve(...)`.
  - Added support for `backend_selection="cupy"` in the existing selection API.
  - Added sparse/candidate CuPy retrieval paths to avoid scanning all documents when sparse query candidates are enough.
  - Added a synthetic benchmark for comparing Numba, dense CuPy, and sparse CuPy retrieval paths.
  - Added CuPy tests for:
    - missing dependency behavior
    - top-k selection
    - backend retrieval
    - mmap retrieval
    - weight masks
    - sparse batch retrieval
    - candidate/SpMM batch retrieval
  - Updated README and test docs with CuPy installation and test instructions.
  - Fixed token-id lookup so vocabulary id `0` is preserved instead of being dropped as falsy.

  ## Notes

  CuPy is intentionally not selected automatically because users need a CuPy package matching their CUDA runtime, for example `cupy-cuda12x`. Users must explicitly choose `backend="cupy"` or
  `backend_selection="cupy"`.

  ## Testing

  Ran locally:

  ```bash
  uv run --with numpy --with scipy --with tqdm --with orjson --with PyStemmer python -m unittest tests/core/test_init_utils.py
  uv run --with numpy --with scipy --with tqdm --with orjson --with PyStemmer python -m unittest discover tests/cupy
  git diff origin/main...HEAD --check

  Results:

  - tests/core/test_init_utils.py: 14 tests passed
  - tests/cupy: 23 tests passed, 20 skipped locally because CuPy/CUDA runtime is not available on this machine
  - diff check passed