### PR TITLE
Add leave_progress and show_progress

### DIFF
--- a/bm25s/__init__.py
+++ b/bm25s/__init__.py
@@ -343,6 +343,9 @@ class BM25:
         corpus_token_ids : List[List[int]]
             List of list of token IDs for each document.
 
+        show_progress : bool
+            If True, a progress bar will be shown. If False, no progress bar will be shown.
+
         leave_progress : bool
             If True, the progress bars will remain after the function completes.
         """
@@ -947,7 +950,8 @@ class BM25:
         nnoc_name="nonoccurrence_array.index.npy",
         corpus_name="corpus.jsonl",
         allow_pickle=False,
-        show_progress=True
+        show_progress=True,
+        leave_progress=False
     ):
         """
         Save the BM25S index to the `save_dir` directory. This will save the scores array,
@@ -990,6 +994,9 @@ class BM25:
 
         show_progress : bool
             If True, a progress bar will be shown. If False, no progress bar will be shown.
+
+        leave_progress : bool
+            If True, the progress bar will remain after the function completes.
         """
         # Save the self.vocab_dict and self.score_matrix to the save_dir
         save_dir = Path(save_dir)
@@ -1061,7 +1068,7 @@ class BM25:
                         f.write(doc_str + "\n")
 
             # also save corpus.mmindex
-            mmidx = utils.corpus.find_newline_positions(save_dir / corpus_name, show_progress=show_progress)
+            mmidx = utils.corpus.find_newline_positions(save_dir / corpus_name, show_progress=show_progress, leave_progress=leave_progress)
             utils.corpus.save_mmindex(mmidx, path=save_dir / corpus_name)
 
     def load_scores(
@@ -1135,6 +1142,8 @@ class BM25:
         allow_pickle=False,
         load_vocab=True,
         override_params: dict = None,
+        show_progress=True,
+        leave_progress=False,
         **kwargs,
     ):
         """
@@ -1189,6 +1198,12 @@ class BM25:
             the parameters of the BM25 object after loading it. For example, you can change auto_compile from
             False to True after loading the object.
         
+        show_progress : bool
+            If True, a progress bar will be shown. If False, no progress bar will be shown.
+
+        leave_progress : bool
+            If True, the progress bar will remain after the function completes.
+
         **kwargs
             Additional arguments are treated as overrides for the parameters.
         """
@@ -1241,7 +1256,7 @@ class BM25:
             corpus_file = save_dir / corpus_name
             if os.path.exists(corpus_file):
                 if mmap is True:
-                    corpus = utils.corpus.JsonlCorpus(corpus_file)
+                    corpus = utils.corpus.JsonlCorpus(corpus_file, show_progress=show_progress, leave_progress=leave_progress)
                 else:
                     corpus = []
                     with open(corpus_file, "r", encoding="utf-8") as f:

--- a/bm25s/hf.py
+++ b/bm25s/hf.py
@@ -184,7 +184,7 @@ To cite `bm25s`, please use the following bibtex:
 """
 
 
-def batch_tokenize(tokenizer, texts, add_special_tokens=False):
+def batch_tokenize(tokenizer, texts, add_special_tokens=False, show_progress=True, leave_progress=False):
     tokenizer_kwargs = dict(
         return_attention_mask=False,
         return_token_type_ids=False,
@@ -195,7 +195,7 @@ def batch_tokenize(tokenizer, texts, add_special_tokens=False):
     output = []
 
     for i in tqdm(
-        range(len(texts)), desc="Processing tokens (huggingface tokenizer)", leave=False
+        range(len(texts)), desc="Processing tokens (huggingface tokenizer)", leave=leave_progress, disable=not show_progress
     ):
         output.append(tokenized[i].tokens)
 
@@ -485,6 +485,8 @@ class BM25HF(BM25):
         overwrite_local: bool = False,
         include_readme: bool = True,
         allow_pickle: bool = False,
+        show_progress: bool = True,
+        leave_progress: bool = False,
         **kwargs,
     ):
         """
@@ -527,6 +529,12 @@ class BM25HF(BM25):
         allow_pickle: bool
             Whether to allow pickling the model. Default is False.
 
+        show_progress: bool
+            Whether to show a progress bar. Default is True.
+
+        leave_progress: bool
+            Whether to leave the progress bar after completion. Default is False.
+
         kwargs: dict
             Additional keyword arguments to pass to `HfApi.upload_folder` call.
         """
@@ -550,7 +558,7 @@ class BM25HF(BM25):
             # save to a temporary directory otherwise
             save_dir = tempfile.mkdtemp()
 
-        self.save(save_dir, corpus=corpus, allow_pickle=allow_pickle)
+        self.save(save_dir, corpus=corpus, allow_pickle=allow_pickle, show_progress=show_progress, leave_progress=leave_progress)
         # if we include the README, write it to the directory
         if include_readme:
             num_docs = self.scores["num_docs"]
@@ -599,6 +607,8 @@ class BM25HF(BM25):
         load_corpus=False,
         mmap=False,
         allow_pickle=False,
+        show_progress=True,
+        leave_progress=False,
     ):
         """
         This function loads the BM25 model from the Hugging Face Hub.
@@ -627,6 +637,12 @@ class BM25HF(BM25):
 
         allow_pickle: bool
             Whether to allow pickling the model. Default is False.
+
+        show_progress: bool
+            Whether to show a progress bar. Default is True.
+
+        leave_progress: bool
+            Whether to leave the progress bar after completion. Default is False.
         """
         api = HfApi(token=token)
         # check if the model exists
@@ -645,4 +661,6 @@ class BM25HF(BM25):
             load_corpus=load_corpus,
             mmap=mmap,
             allow_pickle=allow_pickle,
+            show_progress=show_progress,
+            leave_progress=leave_progress,
         )

--- a/bm25s/utils/beir.py
+++ b/bm25s/utils/beir.py
@@ -48,7 +48,7 @@ def postprocess_results_for_eval(results, scores, query_ids):
     return result_dict_for_eval
 
 
-def merge_cqa_dupstack(data_path):
+def merge_cqa_dupstack(data_path, show_progress=True, leave_progress=False):
     data_path = Path(data_path)
     dataset = data_path.name
     assert dataset == "cqadupstack", "Dataset must be CQADupStack"
@@ -60,13 +60,13 @@ def merge_cqa_dupstack(data_path):
         # corpus files are located under cqadupstack/<name>/corpus.jsonl
         corpus_files = list(data_path.glob("*/corpus.jsonl"))
         with open(corpus_path, "w") as f:
-            for file in tqdm(corpus_files, desc="Merging Corpus", leave=False):
+            for file in tqdm(corpus_files, desc="Merging Corpus", leave=leave_progress, disable=not show_progress):
                 # get the name of the corpus
                 corpus_name = file.parent.name
 
                 with open(file, "r") as f2:
                     for line in tqdm(
-                        f2, desc=f"Merging {corpus_name} Corpus", leave=False
+                        f2, desc=f"Merging {corpus_name} Corpus", leave=leave_progress, disable=not show_progress
                     ):
                         line = json_functions.loads(line)
                         # add the corpus name to _id
@@ -80,13 +80,13 @@ def merge_cqa_dupstack(data_path):
     if not queries_path.exists():
         queries_files = list(data_path.glob("*/queries.jsonl"))
         with open(queries_path, "w") as f:
-            for file in tqdm(queries_files, desc="Merging Queries", leave=False):
+            for file in tqdm(queries_files, desc="Merging Queries", leave=leave_progress, disable=not show_progress):
                 # get the name of the corpus
                 corpus_name = file.parent.name
 
                 with open(file, "r") as f2:
                     for line in tqdm(
-                        f2, desc=f"Merging {corpus_name} Queries", leave=False
+                        f2, desc=f"Merging {corpus_name} Queries", leave=leave_progress, disable=not show_progress
                     ):
                         line = json_functions.loads(line)
                         # add the corpus name to _id
@@ -104,7 +104,7 @@ def merge_cqa_dupstack(data_path):
         with open(qrels_path, "w") as f:
             # First, write the columns: query-id	corpus-id	score
             f.write("query-id\tcorpus-id\tscore\n")
-            for file in tqdm(qrels_files, desc="Merging Qrels", leave=False):
+            for file in tqdm(qrels_files, desc="Merging Qrels", leave=leave_progress, disable=not show_progress):
                 # get the name of the corpus
                 corpus_name = file.parent.parent.name
                 with open(file, "r") as f2:
@@ -112,7 +112,7 @@ def merge_cqa_dupstack(data_path):
                     next(f2)
 
                     for line in tqdm(
-                        f2, desc=f"Merging {corpus_name} Qrels", leave=False
+                        f2, desc=f"Merging {corpus_name} Qrels", leave=leave_progress, disable=not show_progress
                     ):
                         # since it's a tsv, split by tab
                         qid, cid, score = line.strip().split("\t")
@@ -130,6 +130,7 @@ def download_dataset(
     unzip=True,
     redownload=False,
     show_progress=True,
+    leave_progress=False,
 ):
     import urllib.request
     import urllib.error
@@ -150,7 +151,7 @@ def download_dataset(
             unit="B",
             unit_scale=True,
             desc=desc,
-            leave=False,
+            leave=leave_progress,
             disable=not show_progress,
         )
         with open(dst_path, "wb") as f:
@@ -193,7 +194,7 @@ def download_dataset(
             for part_path in tqdm(
                 part_paths,
                 desc=f"Assembling {dataset}",
-                leave=False,
+                leave=leave_progress,
                 disable=not show_progress,
             ):
                 with open(part_path, "rb") as f_in:
@@ -220,7 +221,7 @@ def download_dataset(
 
         # if it's CQADupStack, merge the corpus, queries, and qrels
         if dataset == "cqadupstack":
-            merge_cqa_dupstack(save_dir / dataset)
+            merge_cqa_dupstack(save_dir / dataset, show_progress=show_progress, leave_progress=leave_progress)
 
         return save_dir / dataset
     else:
@@ -232,6 +233,7 @@ def load_jsonl(
     fname,
     save_dir="./datasets",
     show_progress=True,
+    leave_progress=False,
     return_dict=True,
     force_title=False,
     remove=None,
@@ -249,7 +251,7 @@ def load_jsonl(
         pbar = tqdm(
             f,
             desc="[{}] loading {}".format(dataset, fname),
-            leave=False,
+            leave=leave_progress,
             disable=not show_progress,
             total=num_lines,
         )
@@ -269,11 +271,12 @@ def load_jsonl(
     return corpus
 
 
-def load_corpus(dataset, save_dir="./datasets", show_progress=True, return_dict=True):
+def load_corpus(dataset, save_dir="./datasets", show_progress=True, leave_progress=False, return_dict=True):
     return load_jsonl(
         dataset=dataset,
         save_dir=save_dir,
         show_progress=show_progress,
+        leave_progress=leave_progress,
         return_dict=return_dict,
         fname="corpus.jsonl",
         force_title=True,
@@ -281,11 +284,12 @@ def load_corpus(dataset, save_dir="./datasets", show_progress=True, return_dict=
     )
 
 
-def load_queries(dataset, save_dir="./datasets", show_progress=True, return_dict=True):
+def load_queries(dataset, save_dir="./datasets", show_progress=True, leave_progress=False, return_dict=True):
     return load_jsonl(
         dataset=dataset,
         save_dir=save_dir,
         show_progress=show_progress,
+        leave_progress=leave_progress,
         return_dict=return_dict,
         fname="queries.jsonl",
         force_title=False,
@@ -294,7 +298,7 @@ def load_queries(dataset, save_dir="./datasets", show_progress=True, return_dict
 
 
 def load_qrels(
-    dataset, split="test", save_dir="./datasets", show_progress=True, return_dict=True
+    dataset, split="test", save_dir="./datasets", show_progress=True, leave_progress=False, return_dict=True
 ):
     """
     This is tsv files
@@ -315,7 +319,7 @@ def load_qrels(
         for line in tqdm(
             f,
             desc="Loading Qrels {}".format(dataset),
-            leave=False,
+            leave=leave_progress,
             disable=not show_progress,
         ):
             qid, cid, score = line.strip().split("\t")


### PR DESCRIPTION
A couple of functions that use tqdm directly or indirectly were missing leave_progress and show_progress params.
I made sure that they use those config params, as in other functions.

High level and CLI were omitted on purpose.

Note: some functions have 'leave' instead of 'leave_progress', I have not touched this to not break API.